### PR TITLE
Correct usage of ll in %d and %x

### DIFF
--- a/test/linux/slaveinfo/slaveinfo.c
+++ b/test/linux/slaveinfo/slaveinfo.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "ethercattype.h"
 #include "nicdrv.h"
@@ -155,7 +156,7 @@ char* SDO2string(uint16 slave, uint16 index, uint8 subidx, uint16 dtype)
             break;
          case ECT_INTEGER64:
             i64 = (int64*) &usdo[0];
-            sprintf(hstr, "0x%16.16llx %lld", *i64, *i64);
+            sprintf(hstr, "0x%16.16"PRIx64" %"PRId64, *i64, *i64);
             break;
          case ECT_UNSIGNED8:
             u8 = (uint8*) &usdo[0];
@@ -172,7 +173,7 @@ char* SDO2string(uint16 slave, uint16 index, uint8 subidx, uint16 dtype)
             break;
          case ECT_UNSIGNED64:
             u64 = (uint64*) &usdo[0];
-            sprintf(hstr, "0x%16.16llx %llu", *u64, *u64);
+            sprintf(hstr, "0x%16.16"PRIx64" %"PRIu64, *u64, *u64);
             break;
          case ECT_REAL32:
             sr = (float*) &usdo[0];

--- a/test/win32/slaveinfo/slaveinfo.c
+++ b/test/win32/slaveinfo/slaveinfo.c
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "ethercattype.h"
 #include "nicdrv.h"
@@ -155,7 +156,7 @@ char* SDO2string(uint16 slave, uint16 index, uint8 subidx, uint16 dtype)
             break;
          case ECT_INTEGER64:
             i64 = (int64*) &usdo[0];
-            sprintf(hstr, "0x%16.16llx %lld", *i64, *i64);
+            sprintf(hstr, "0x%16.16"PRIx64" %"PRId64, *i64, *i64);
             break;
          case ECT_UNSIGNED8:
             u8 = (uint8*) &usdo[0];
@@ -172,7 +173,7 @@ char* SDO2string(uint16 slave, uint16 index, uint8 subidx, uint16 dtype)
             break;
          case ECT_UNSIGNED64:
             u64 = (uint64*) &usdo[0];
-            sprintf(hstr, "0x%16.16llx %llu", *u64, *u64);
+            sprintf(hstr, "0x%16.16"PRIx64" %"PRIu64, *u64, *u64);
             break;
          case ECT_REAL32:
             sr = (float*) &usdo[0];


### PR DESCRIPTION
In 64-bit OSes, `int64_t` is just `long`. Using %lld` is wrong. This commit makes sure `%lld` always sees a `long long` regardless of architecture.