### PR TITLE
Fixed mastertime64 calculation

### DIFF
--- a/soem/ethercatdc.c
+++ b/soem/ethercatdc.c
@@ -296,7 +296,7 @@ boolean ecx_configdc(ecx_contextt *context)
    ecx_BWR(context->port, 0, ECT_REG_DCTIME0, sizeof(ht), &ht, EC_TIMEOUTRET);  /* latch DCrecvTimeA of all slaves */
    mastertime = osal_current_time();
    mastertime.sec -= 946684800UL;  /* EtherCAT uses 2000-01-01 as epoch start instead of 1970-01-01 */
-   mastertime64 = (((uint64)mastertime.sec * 1000000) + (uint64)mastertime.usec) * 1000;
+   mastertime64 = (((uint64)mastertime.sec * 1000000000) + (uint64)mastertime.usec) * 1000;
    for (i = 1; i <= *(context->slavecount); i++)
    {
       context->slavelist[i].consumedports = context->slavelist[i].activeports;


### PR DESCRIPTION
calculation of Master time (nanoseconds since 2000-01-01 epoch) did not correctly translate seconds into nanoseconds