### PR TITLE
Rxbufstat

### DIFF
--- a/oshw/intime/nicdrv.c
+++ b/oshw/intime/nicdrv.c
@@ -137,7 +137,13 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
    if (status != E_OK)
    {
       ECAT_PRINT_ERROR("hpeOpen failed with status %04x ", status);
+      if(status == E_EXIST) ECAT_PRINT_ERROR("E_EXIST\n");
+      else if(status == E_STATE) ECAT_PRINT_ERROR("E_STATE\n");
       else if(status == E_PARAM) ECAT_PRINT_ERROR("E_PARAM\n");
+      else if(status == E_INVALID_ADDR) ECAT_PRINT_ERROR("E_INVALID_ADDR\n");
+      else if(status == E_IO) ECAT_PRINT_ERROR("E_IO\n");
+      else if(status == E_TIME) ECAT_PRINT_ERROR("E_TIME\n");
+      else ECAT_PRINT_ERROR("UNKNOWN\n");
       result = 0;
       goto end;
    }

--- a/oshw/intime/nicdrv.c
+++ b/oshw/intime/nicdrv.c
@@ -137,13 +137,7 @@ int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
    if (status != E_OK)
    {
       ECAT_PRINT_ERROR("hpeOpen failed with status %04x ", status);
-	  if(status == E_EXIST) ECAT_PRINT_ERROR("E_EXIST\n");
-	  else if(status == E_STATE) ECAT_PRINT_ERROR("E_STATE\n");
       else if(status == E_PARAM) ECAT_PRINT_ERROR("E_PARAM\n");
-	  else if(status == E_INVALID_ADDR) ECAT_PRINT_ERROR("E_INVALID_ADDR\n");
-	  else if(status == E_IO) ECAT_PRINT_ERROR("E_IO\n");
-	  else if(status == E_TIME) ECAT_PRINT_ERROR("E_TIME\n");
-	  else ECAT_PRINT_ERROR("UNKNOWN\n");
       result = 0;
       goto end;
    }
@@ -534,6 +528,7 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
    }
    else
    {
+      WaitForRtControl(port->rx_region);
       /* non blocking call to retrieve frame from socket */
       if (ecx_recvpkt(port, stacknumber))
       {
@@ -572,6 +567,7 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
             }
          }
       }
+      ReleaseRtControl();
    }
 
    /* WKC if mathing frame found */

--- a/oshw/linux/nicdrv.c
+++ b/oshw/linux/nicdrv.c
@@ -453,8 +453,8 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
             }
             else
             {
-               /* check if index exist? */
-               if (idxf < EC_MAXBUF)
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
                {
                   rxbuf = &(*stack->rxbuf)[idxf];
                   /* put it in the buffer array (strip ethernet header) */

--- a/oshw/rtk/nicdrv.c
+++ b/oshw/rtk/nicdrv.c
@@ -440,8 +440,8 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
             }
             else
             {
-               /* check if index exist? */
-               if (idxf < EC_MAXBUF)
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
                {
                   rxbuf = &(*stack->rxbuf)[idxf];
                   /* put it in the buffer array (strip ethernet header) */

--- a/oshw/win32/nicdrv.c
+++ b/oshw/win32/nicdrv.c
@@ -457,8 +457,8 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
             }
             else
             {
-               /* check if index exist? */
-               if (idxf < EC_MAXBUF)
+               /* check if index exist and someone is waiting for it */
+               if (idxf < EC_MAXBUF && (*stack->rxbufstat)[idxf] == EC_BUF_TX)
                {
                   rxbuf = &(*stack->rxbuf)[idxf];
                   /* put it in the buffer array (strip ethernet header) */
@@ -584,11 +584,6 @@ int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
 
    osal_timer_start (&timer, timeout);
    wkc = ecx_waitinframe_red(port, idx, &timer);
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ec_setbufstat(idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }


### PR DESCRIPTION
Improved multithreading
-Add condition to mark frame as RCVD, it must be send and marked TX
-Remove misplaced mark frame EMPTY in ecx_waitinframe, it is handled by the caller later, sr_confirm and receive processdata.
-Add mutex in InTime receive to protect RX tempbuf 