### PR TITLE
allow setting CMAKE_INSTALL_PREFIX externally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,12 @@ cmake_minimum_required(VERSION 2.8.4)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 project(SOEM C)
 
-if(DEFINED HOST_INSTALL)
-   set(SOEM_INCLUDE_INSTALL_DIR include/soem)
-else()
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+   # Default to installing in SOEM source directory
    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/install)
-   set(SOEM_INCLUDE_INSTALL_DIR include)
 endif()
+
+set(SOEM_INCLUDE_INSTALL_DIR include/soem)
 
 message("CMAKE_SYSTEM_NAME is ${CMAKE_SYSTEM_NAME}")
 

--- a/test/linux/simple_test/CMakeLists.txt
+++ b/test/linux/simple_test/CMakeLists.txt
@@ -9,6 +9,4 @@ elseif(UNIX)
    target_link_libraries(simple_test pthread rt)
 endif()
 
-if(NOT DEFINED HOST_INSTALL)
-   install(TARGETS simple_test DESTINATION bin)
-endif()
+install(TARGETS simple_test DESTINATION bin)


### PR DESCRIPTION
This lets the user specify CMAKE_INSTALL_PREFIX on the command line. Also removes -DHOST_INSTALL as you can specify -DCMAKE_INSTALL_PREFIX=/usr/local instead. Note that the include install path is now always include/soem.
