### PR TITLE
nicdrv.c changes for VxWorks 6.9 target

### DIFF
--- a/oshw/vxworks/nicdrv.c
+++ b/oshw/vxworks/nicdrv.c
@@ -459,6 +459,7 @@ static int ec_outfram_send(ETHERCAT_PKT_DEV * pPktDev, void * buf, int len)
    pPacket->mBlkHdr.mLen = len;
    pPacket->mBlkHdr.mFlags |= M_HEADER;
    pPacket->mBlkHdr.mData = pPacket->pClBlk->clNode.pClBuf;
+   pPacket->mBlkPktHdr.len  = len; 
 
    netMblkFromBufCopy(pPacket, buf, 0, pPacket->mBlkHdr.mLen, M_DONTWAIT, NULL);
    status = muxTkSend(pPktDev->pCookie, pPacket, NULL, htons(ETH_P_ECAT), NULL);


### PR DESCRIPTION
As I learned from WRS for some old network cards it works without to set this but for the new one we need also to set mBlkPktHdr.len. Their advice is to set also this filed for mBlk structure when muxSend is used.