### PR TITLE
Add functions to configure and send an overlapping IOmap

### DIFF
--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -22,14 +22,18 @@ extern "C"
 #ifdef EC_VER1
 int ec_config_init(uint8 usetable);
 int ec_config_map(void *pIOmap);
+int ec_config_overlap_map(void *pIOmap);
 int ec_config_map_group(void *pIOmap, uint8 group);
+int ec_config_overlap_map_group(void *pIOmap, uint8 group);
 int ec_config(uint8 usetable, void *pIOmap);
+int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
 int ec_reconfig_slave(uint16 slave, int timeout);
 #endif
 
 int ecx_config_init(ecx_contextt *context, uint8 usetable);
 int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
+int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_recover_slave(ecx_contextt *context, uint16 slave, int timeout);
 int ecx_reconfig_slave(ecx_contextt *context, uint16 slave, int timeout);
 

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -467,8 +467,10 @@ int ec_writeeepromFP(uint16 configadr, uint16 eeproma, uint16 data, int timeout)
 void ec_readeeprom1(uint16 slave, uint16 eeproma);
 uint32 ec_readeeprom2(uint16 slave, int timeout);
 int ec_send_processdata_group(uint8 group);
+int ec_send_overlap_processdata_group(uint8 group);
 int ec_receive_processdata_group(uint8 group, int timeout);
 int ec_send_processdata(void);
+int ec_send_overlap_processdata(void);
 int ec_receive_processdata(int timeout);
 #endif
 
@@ -507,9 +509,10 @@ uint64 ecx_readeepromFP(ecx_contextt *context, uint16 configadr, uint16 eeproma,
 int ecx_writeeepromFP(ecx_contextt *context, uint16 configadr, uint16 eeproma, uint16 data, int timeout);
 void ecx_readeeprom1(ecx_contextt *context, uint16 slave, uint16 eeproma);
 uint32 ecx_readeeprom2(ecx_contextt *context, uint16 slave, int timeout);
-int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
+int ecx_send_overlap_processdata_group(ecx_contextt *context, uint8 group);
 int ecx_receive_processdata_group(ecx_contextt *context, uint8 group, int timeout);
 int ecx_send_processdata(ecx_contextt *context);
+int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Main objectiv: Workaround for TI ESC errata  – SDOCM00105048/PINDSW-141: LRW access to non-interleaved input and output process data of multiple slaves does not work. SOEM accesses slaves in LRW mode this way

Also: Using an overlapped LRW frame get smaller per definition
