### PR TITLE
Increased size of EEPROM buffer in eepromtool.c

### DIFF
--- a/test/linux/eepromtool/eepromtool.c
+++ b/test/linux/eepromtool/eepromtool.c
@@ -20,7 +20,7 @@
 
 #include "ethercat.h"
 
-#define MAXBUF 32768
+#define MAXBUF 524288
 #define STDBUF 2048
 #define MINBUF 128
 #define CRCBUF 14


### PR DESCRIPTION
This PR increases the size eepromtool can read/write to 4 megabit, which is the maximum slave devices seem to support according to the datasheets.

Due to space constraints on our device we store some application specific data on our slave that exceeds 32kbyte, hence the need for the ability to read/write larger images to EEPROM.