### PR TITLE
Allow seting the desired end state in ecx_config_init

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -309,7 +309,7 @@ static int ecx_lookup_prev_sii(ecx_contextt *context, uint16 slave)
  * @param[in] state        = Desired state after init. Valid options are EC_STATE_INIT, EC_STATE_BOOT or EC_STATE_PRE_OP
  * @return Workcounter of slave discover datagram = number of slaves found
  */
-int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, ec_state state)
+int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, uint16 state)
 {
    uint16 slave, ADPh, configadr, ssigen;
    uint16 topology, estat;
@@ -592,9 +592,9 @@ int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, ec_state sta
          {
             /* some slaves need eeprom available to PDI in init->preop or init->boot transition */
             ecx_eeprom2pdi(context, slave);
-            /* request pre_op for slave */
-            ecx_FPWRw(context->port, configadr, ECT_REG_ALCTL, htoes(state | EC_STATE_ACK) , EC_TIMEOUTRET3); /* set desired status */
          }
+         /* request desired state for slave */
+         ecx_FPWRw(context->port, configadr, ECT_REG_ALCTL, htoes(state | EC_STATE_ACK) , EC_TIMEOUTRET3); /* set desired status */
       }
    }
    return wkc;

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -32,7 +32,7 @@ int ec_reconfig_slave(uint16 slave, int timeout);
 #endif
 
 int ecx_config_init(ecx_contextt *context, uint8 usetable);
-int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, ec_state state);
+int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, uint16 state);
 int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_recover_slave(ecx_contextt *context, uint16 slave, int timeout);

--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -32,6 +32,7 @@ int ec_reconfig_slave(uint16 slave, int timeout);
 #endif
 
 int ecx_config_init(ecx_contextt *context, uint8 usetable);
+int ecx_config_init_to_state(ecx_contextt *context, uint8 usetable, ec_state state);
 int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_recover_slave(ecx_contextt *context, uint16 slave, int timeout);


### PR DESCRIPTION
This PR adds a new function ecx_config_init_to_state which adds the final desired state to ecx_config_init. Valid states would be INIT, BOOT and PRE_OP.

ecx_config_init calls ecx_config_init_to_state with PRE_OP as desired state.


This PR makes it possible to go directly from INIT to BOOT to re-attempt a firmware update. In our slave, the bootloader will exit once the slave is requested to go to PRE_OP. Should a firmware upgrade fail, there is no way to go the BOOT mode if the ecx_config_init transitions the slave to PRE_OP before then.