### PR TITLE
Fix race condition in rxbufstat

### DIFF
--- a/oshw/intime/nicdrv.c
+++ b/oshw/intime/nicdrv.c
@@ -363,15 +363,16 @@ int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
    }
    log_RT_event('S',(WORD)3);
 
+   (*stack->rxbufstat)[idx] = EC_BUF_TX;
    status = hpeStartTransmitter(port->handle);
    if (status != E_OK)
    {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
       result = -3;
       goto end;
    }
 
    log_RT_event('S',(WORD)4);
-   (*stack->rxbufstat)[idx] = EC_BUF_TX;
    result = lp;
 
 end:
@@ -408,9 +409,13 @@ int ecx_outframe_red(ecx_portt *port, int idx)
       //send(sockhandle2, &ec_txbuf2, ec_txbuflength2 , 0);
       // OBS! redundant not ACTIVE for BFIN, just added to compile
       //ASSERT (0);
-	   hpeAttachTransmitBufferSet(port->redport->handle, port->tx_buffers[idx]);
-      status = hpeStartTransmitter(port->redport->handle);
+      hpeAttachTransmitBufferSet(port->redport->handle, port->tx_buffers[idx]);
       port->redport->rxbufstat[idx] = EC_BUF_TX;
+      status = hpeStartTransmitter(port->redport->handle);
+      if (status != E_OK)
+      {
+         (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+      }
    }
 
    return rval;

--- a/oshw/rtems/nicdrv.c
+++ b/oshw/rtems/nicdrv.c
@@ -327,8 +327,12 @@ int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
    }
    lp = (*stack->txbuflength)[idx];
    //rval = send(*stack->sock, (*stack->txbuf)[idx], lp, 0);
-   rval = write (*stack->sock,(*stack->txbuf)[idx], lp);
    (*stack->rxbufstat)[idx] = EC_BUF_TX;
+   rval = write (*stack->sock,(*stack->txbuf)[idx], lp);
+   if (rval == -1)
+   {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+   }
 
    return rval;
 }
@@ -361,9 +365,12 @@ int ecx_outframe_red(ecx_portt *port, int idx)
       ehp->sa1 = htons(secMAC[1]);
       /* transmit over secondary socket */
       //send(port->redport->sockhandle, &(port->txbuf2), port->txbuflength2 , 0);
-      write(port->redport->sockhandle, &(port->txbuf2), port->txbuflength2);
-      pthread_mutex_unlock( &(port->tx_mutex) );
       port->redport->rxbufstat[idx] = EC_BUF_TX;
+      if (write(port->redport->sockhandle, &(port->txbuf2), port->txbuflength2) == -1)
+      {
+         (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+      }
+      pthread_mutex_unlock( &(port->tx_mutex) );
    }
 
    return rval;

--- a/oshw/rtk/nicdrv.c
+++ b/oshw/rtk/nicdrv.c
@@ -262,8 +262,8 @@ int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
       stack = &(port->redport->stack);
    }
    lp = (*stack->txbuflength)[idx];
-   rval = bfin_EMAC_send((*stack->txbuf)[idx], lp);
    (*stack->rxbufstat)[idx] = EC_BUF_TX;
+   rval = bfin_EMAC_send((*stack->txbuf)[idx], lp);
 
    return rval;
 }
@@ -298,9 +298,9 @@ int ecx_outframe_red(ecx_portt *port, int idx)
       //send(sockhandle2, &ec_txbuf2, ec_txbuflength2 , 0);
       // OBS! redundant not ACTIVE for BFIN, just added to compile
       ASSERT (0);
+      port->redport->rxbufstat[idx] = EC_BUF_TX;
       bfin_EMAC_send(&(port->txbuf2), port->txbuflength2);
       mtx_unlock (port->tx_mutex);
-      port->redport->rxbufstat[idx] = EC_BUF_TX;
    }
 
    return rval;

--- a/oshw/vxworks/nicdrv.c
+++ b/oshw/vxworks/nicdrv.c
@@ -474,12 +474,16 @@ int ecx_outframe(ecx_portt *port, int idx, int stacknumber)
       pPktDev = &(port->redport->pktDev);
    }
 
+   (*stack->rxbufstat)[idx] = EC_BUF_TX;
    rval = ec_outfram_send(pPktDev, (char*)(*stack->txbuf)[idx], 
                           (*stack->txbuflength)[idx]);
    if (rval > 0)
    {
-      (*stack->rxbufstat)[idx] = EC_BUF_TX;
       port->pktDev.tx_count++;
+   }
+   else
+   {
+      (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
    }
    
    return rval;
@@ -511,8 +515,12 @@ int ecx_outframe_red(ecx_portt *port, int idx)
       /* rewrite MAC source address 1 to secondary */
       ehp->sa1 = htons(secMAC[1]);
       /* transmit over secondary interface */
-      rval = ec_outfram_send(&(port->redport->pktDev), &(port->txbuf2), port->txbuflength2);
       port->redport->rxbufstat[idx] = EC_BUF_TX;
+      rval = ec_outfram_send(&(port->redport->pktDev), &(port->txbuf2), port->txbuflength2);
+      if (rval <= 0)
+      {
+         (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+      }
    }   
    
    return rval;


### PR DESCRIPTION
I skip return checking in oshw/rtk because there already have ASSERT inside bfin_EMAC_send