### PR TITLE
Adds BUILD_SHARED_LIBS option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,10 +6,14 @@ if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   # Default to installing in SOEM source directory
   set(CMAKE_INSTALL_PREFIX ${CMAKE_CURRENT_LIST_DIR}/install)
 endif()
+message("CMAKE_INSTALL_PREFIX is ${CMAKE_INSTALL_PREFIX}")
 
 set(SOEM_INCLUDE_INSTALL_DIR include/soem)
 set(SOEM_LIB_INSTALL_DIR lib)
 set(BUILD_TESTS TRUE)
+
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+message("BUILD_SHARED_LIBS is ${BUILD_SHARED_LIBS}")
 
 if(WIN32)
   set(OS "win32")
@@ -60,12 +64,26 @@ file(GLOB SOEM_HEADERS soem/*.h)
 file(GLOB OSAL_HEADERS osal/osal.h osal/${OS}/*.h)
 file(GLOB OSHW_HEADERS oshw/${OS}/*.h)
 
-add_library(soem STATIC
-  ${SOEM_SOURCES}
-  ${OSAL_SOURCES}
-  ${OSHW_SOURCES}
-  ${OSHW_EXTRA_SOURCES})
-target_link_libraries(soem ${OS_LIBS})
+include_directories(soem)
+include_directories(osal)
+include_directories(osal/${OS})
+include_directories(oshw/${OS})
+
+if(BUILD_SHARED_LIBS)
+  add_library(soem SHARED
+    ${SOEM_SOURCES}
+    ${OSAL_SOURCES}
+    ${OSHW_SOURCES}
+    ${OSHW_EXTRA_SOURCES})
+  target_link_libraries(soem ${OS_LIBS})
+else()
+  add_library(soem STATIC
+    ${SOEM_SOURCES}
+    ${OSAL_SOURCES}
+    ${OSHW_SOURCES}
+    ${OSHW_EXTRA_SOURCES})
+    target_link_libraries(soem ${OS_LIBS})
+endif()
 
 target_include_directories(soem PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/soem>
@@ -96,7 +114,7 @@ install(FILES
   ${OSHW_HEADERS}
   DESTINATION ${SOEM_INCLUDE_INSTALL_DIR})
 
-if(BUILD_TESTS) 
+if(BUILD_TESTS)
   add_subdirectory(test/linux/slaveinfo)
   add_subdirectory(test/linux/eepromtool)
   add_subdirectory(test/linux/simple_test)


### PR DESCRIPTION
It is basically the same as https://github.com/OpenEtherCATsociety/SOEM/pull/89 by @thopiekar but configured opt-out to keep the current default build procedure as static and not break pipelines around

It also provides feedback about the install prefix, since it is usually `/usr/local` and not `CMAKE_SOURCE_DIR`

Suggestions welcome!