### PR TITLE
update PO2SOconfig to add a ecx_contextt* in callback argument.

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -646,7 +646,7 @@ static int ecx_map_coe_soe(ecx_contextt *context, uint16 slave, int thread_n)
    /* execute special slave configuration hook Pre-Op to Safe-OP */
    if(context->slavelist[slave].PO2SOconfig) /* only if registered */
    {
-      context->slavelist[slave].PO2SOconfig(slave);
+      context->slavelist[slave].PO2SOconfig(context, slave);
    }
    /* if slave not found in configlist find IO mapping in slave self */
    if (!context->slavelist[slave].configindex)
@@ -1522,7 +1522,7 @@ int ecx_reconfig_slave(ecx_contextt *context, uint16 slave, int timeout)
          /* execute special slave configuration hook Pre-Op to Safe-OP */
          if(context->slavelist[slave].PO2SOconfig) /* only if registered */
          {
-            context->slavelist[slave].PO2SOconfig(slave);
+            context->slavelist[slave].PO2SOconfig(context, slave);
          }
          ecx_FPWRw(context->port, configadr, ECT_REG_ALCTL, htoes(EC_STATE_SAFE_OP) , timeout); /* set safeop status */
          state = ecx_statecheck(context, slave, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE); /* check state change safe-op */

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -226,7 +226,7 @@ typedef struct ec_slave
    /** Boolean for tracking whether the slave is (not) responding, not used/set by the SOEM library */
    boolean          islost;
    /** registered configuration function PO->SO */
-   int              (*PO2SOconfig)(uint16 slave);
+   int              (*PO2SOconfig)(void *context, uint16 slave);
    /** readable name */
    char             name[EC_MAXNAME + 1];
 } ec_slavet;

--- a/test/win32/simple_test/simple_test.c
+++ b/test/win32/simple_test/simple_test.c
@@ -38,7 +38,7 @@ void CALLBACK RTthread(UINT uTimerID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1
     /* do RT control stuff here */
 }
 
-int EL7031setup(uint16 slave)
+int EL7031setup(void *context, uint16 slave)
 {
     int retval;
     uint16 u16val;
@@ -73,7 +73,7 @@ int EL7031setup(uint16 slave)
     return 1;
 }
 
-int AEPsetup(uint16 slave)
+int AEPsetup(void *context, uint16 slave)
 {
     int retval;
     uint8 u8val;


### PR DESCRIPTION
Update PO2SOconfig callback to add ecx_contextt* context as a parameter in callback function in order to make it convenient for using the interface 'ecx_xxx' (not using the EC_VER1 apis)