### PR TITLE
Fix in aliastool.c

### DIFF
--- a/test/linux/aliastool.c
+++ b/test/linux/aliastool.c
@@ -404,7 +404,7 @@ int main(int argc, char *argv[])
         if ((strncmp(argv[3], "-walias", sizeof("-walias")) == 0))
 	    {
 	       mode = MODE_WRITEALIAS;
-		   alias = atoi(argv(4));
+		   alias = atoi(argv[4]);
 	    }
       }
       /* start tool */


### PR DESCRIPTION
A minor fix in aliastool.c. Just changed argv(4) to argv[v]. The aliastool.c is not included in CMakeLists.txt for the build, that's why it didn't throw an error.