### PR TITLE
Bug with first slave with many PDOs and DC enabled. 

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -1171,7 +1171,7 @@ int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
                oLogAddr = LogAddr;
                if ((segmentsize + diff) > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM))
                {
-                  context->grouplist[group].IOsegment[currentsegment] = segmentsize;
+                  context->grouplist[group].IOsegment[currentsegment] = segmentsize > 0 ? segmentsize:EC_FIRSTDCDATAGRAM;
                   if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                   {
                      currentsegment++;
@@ -1230,7 +1230,7 @@ int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
                oLogAddr = LogAddr;
                if ((segmentsize + diff) > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM))
                {
-                  context->grouplist[group].IOsegment[currentsegment] = segmentsize;
+                  context->grouplist[group].IOsegment[currentsegment] = segmentsize > 0 ? segmentsize:EC_FIRSTDCDATAGRAM;
                   if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                   {
                      currentsegment++;
@@ -1363,7 +1363,7 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
 
             if ((segmentsize + diff) > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM))
             {
-               context->grouplist[group].IOsegment[currentsegment] = segmentsize;
+               context->grouplist[group].IOsegment[currentsegment] = segmentsize > 0 ? segmentsize:EC_FIRSTDCDATAGRAM;
                if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                {
                   currentsegment++;


### PR DESCRIPTION
If the first slave has DC enabled and enouh PDOs to need more than [EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM] bytes in the process image, the first segment's size will be zero instead of EC_FIRSTDCDATAGRAM and this cause the wrongly reading for the wkc at receiving time.