### PR TITLE
Re-init when error acknowledge fails

### DIFF
--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -229,6 +229,8 @@ typedef struct ec_slave
    int              (*PO2SOconfig)(uint16 slave);
    /** readable name */
    char             name[EC_MAXNAME + 1];
+   /** To keep track of failed SAFE_OP -> OP attempts **/
+   uint8            toOPFailCntr;
 } ec_slavet;
 
 /** for list of ethercat slave groups */

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -167,8 +167,14 @@ OSAL_THREAD_FUNC ecatcheck( void *ptr )
                   ec_group[currentgroup].docheckstate = TRUE;
                   if (ec_slave[slave].state == (EC_STATE_SAFE_OP + EC_STATE_ERROR))
                   {
-                     printf("ERROR : slave %d is in SAFE_OP + ERROR, attempting ack.\n", slave);
-                     ec_slave[slave].state = (EC_STATE_SAFE_OP + EC_STATE_ACK);
+                     if(ec_slave[slave].toOPFailCntr<5){
+                           printf("ERROR : slave %d is in SAFE_OP + ERROR, attempting ack.\n", slave);
+                           ec_slave[slave].state = (EC_STATE_SAFE_OP + EC_STATE_ACK);
+                           ec_slave[slave].toOPFailCntr++;
+                     }else{
+                           printf("ERROR : slave %d is still in SAFE_OP + ERROR, attempting re-init.\n", slave);
+                           ec_slave[slave].state = (EC_STATE_INIT);
+                     }
                      ec_writestate(slave);
                   }
                   else if(ec_slave[slave].state == EC_STATE_SAFE_OP)
@@ -203,12 +209,14 @@ OSAL_THREAD_FUNC ecatcheck( void *ptr )
                      if (ec_recover_slave(slave, EC_TIMEOUTMON))
                      {
                         ec_slave[slave].islost = FALSE;
+                        ec_slave[slave].toOPFailCntr = 0;
                         printf("MESSAGE : slave %d recovered\n",slave);
                      }
                   }
                   else
                   {
                      ec_slave[slave].islost = FALSE;
+                     ec_slave[slave].toOPFailCntr = 0;
                      printf("MESSAGE : slave %d found\n",slave);
                   }
                }

--- a/test/win32/simple_test/simple_test.c
+++ b/test/win32/simple_test/simple_test.c
@@ -285,8 +285,14 @@ OSAL_THREAD_FUNC ecatcheck(void *lpParam)
                   ec_group[currentgroup].docheckstate = TRUE;
                   if (ec_slave[slave].state == (EC_STATE_SAFE_OP + EC_STATE_ERROR))
                   {
-                     printf("ERROR : slave %d is in SAFE_OP + ERROR, attempting ack.\n", slave);
-                     ec_slave[slave].state = (EC_STATE_SAFE_OP + EC_STATE_ACK);
+                     if(ec_slave[slave].toOPFailCntr<5){
+                           printf("ERROR : slave %d is in SAFE_OP + ERROR, attempting ack.\n", slave);
+                           ec_slave[slave].state = (EC_STATE_SAFE_OP + EC_STATE_ACK);
+                           ec_slave[slave].toOPFailCntr++;
+                     }else{
+                           printf("ERROR : slave %d is still in SAFE_OP + ERROR, attempting re-init.\n", slave);
+                           ec_slave[slave].state = (EC_STATE_INIT);
+                     }
                      ec_writestate(slave);
                   }
                   else if(ec_slave[slave].state == EC_STATE_SAFE_OP)
@@ -321,12 +327,14 @@ OSAL_THREAD_FUNC ecatcheck(void *lpParam)
                      if (ec_recover_slave(slave, EC_TIMEOUTMON))
                      {
                         ec_slave[slave].islost = FALSE;
+                        ec_slave[slave].toOPFailCntr = 0;
                         printf("MESSAGE : slave %d recovered\n",slave);
                      }
                   }
                   else
                   {
                      ec_slave[slave].islost = FALSE;
+                     ec_slave[slave].toOPFailCntr = 0;
                      printf("MESSAGE : slave %d found\n",slave);
                   }
                }


### PR DESCRIPTION
I found that some (old) slaves do not respond to EC_STATE_SAFE_OP + EC_STATE_ACK correctly. The work-counter is correctly updated but the state is stuck in EC_STATE_SAFE_OP + EC_STATE_ERROR. If this acknowledge fails multiple times I suggest to do a re-init of that slave. This succeeds in bringing the slave back to EC_STATE_OPERATIONAL.

The fix works, but please comment whether this is the neatest implementation.