### PR TITLE
improve groups, make memory usage more efficient, fix erroneous byte …

### DIFF
--- a/soem/ethercatdc.c
+++ b/soem/ethercatdc.c
@@ -281,8 +281,8 @@ boolean ecx_configdc(ecx_contextt *context)
             context->slavelist[0].hasdc = TRUE;
             context->slavelist[0].DCnext = i;
             context->slavelist[i].DCprevious = 0;
-            context->grouplist[0].hasdc = TRUE;
-            context->grouplist[0].DCnext = i;
+            context->grouplist[context->slavelist[i].group].hasdc = TRUE;
+            context->grouplist[context->slavelist[i].group].DCnext = i;
          }
          else
          {

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -517,6 +517,7 @@ int ecx_receive_processdata_group(ecx_contextt *context, uint8 group, int timeou
 int ecx_send_processdata(ecx_contextt *context);
 int ecx_send_overlap_processdata(ecx_contextt *context);
 int ecx_receive_processdata(ecx_contextt *context, int timeout);
+int ecx_send_processdata_group(ecx_contextt *context, uint8 group);
 
 #ifdef __cplusplus
 }

--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -71,6 +71,8 @@ extern "C"
 #define EC_MAXEEPBUF       EC_MAXEEPBITMAP << 5
 /** default number of retries if wkc <= 0 */
 #define EC_DEFAULTRETRIES  3
+/** default group size in 2^x */
+#define EC_LOGGROUPOFFSET 16
 
 /** definition for frame buffers */
 typedef uint8 ec_bufT[EC_BUFSIZE];


### PR DESCRIPTION
…calculations and dc frame handling

Use case, separate IOmap per group, it is undocumented if/how usage of _map_groups( .., >0) should/will work. 

This PR will handle these scenarios where the second would be legacy

char iomap1[4096];
char iomap2[2048];
char iomap3[1024];

ecx_config_map_group(iomap1, 1);
ecx_config_map_group(iomap2, 2);
ecx_config_map_group(iomap3, 3);

alt 

char iomap[4096];  
ecx_config_map(iomap);  typ ecx_config_map_group(iomap, 0);