### PR TITLE
Remove possible racecondition of set buf EMPTY

### DIFF
--- a/oshw/linux/nicdrv.c
+++ b/oshw/linux/nicdrv.c
@@ -554,11 +554,6 @@ int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
 
    osal_timer_start (&timer, timeout);
    wkc = ecx_waitinframe_red(port, idx, &timer);
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }
@@ -598,11 +593,6 @@ int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
       wkc = ecx_waitinframe_red(port, idx, &timer2);
    /* wait for answer with WKC>=0 or otherwise retry until timeout */
    } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }

--- a/oshw/rtems/nicdrv.c
+++ b/oshw/rtems/nicdrv.c
@@ -605,11 +605,6 @@ int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
 
    osal_timer_start (&timer, timeout);
    wkc = ecx_waitinframe_red(port, idx, &timer);
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }
@@ -649,11 +644,6 @@ int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
       wkc = ecx_waitinframe_red(port, idx, &timer2);
    /* wait for answer with WKC>=0 or otherwise retry until timeout */
    } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }

--- a/oshw/rtk/nicdrv.c
+++ b/oshw/rtk/nicdrv.c
@@ -541,11 +541,6 @@ int ecx_waitinframe(ecx_portt *port, int idx, int timeout)
 
    osal_timer_start (&timer, timeout);
    wkc = ecx_waitinframe_red(port, idx, timer);
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }
@@ -579,11 +574,6 @@ int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
       wkc = ecx_waitinframe_red(port, idx, read_timer);
    /* wait for answer with WKC>0 or otherwise retry until timeout */
    } while ((wkc <= EC_NOFRAME) && (osal_timer_is_expired(&timer) == FALSE));
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }

--- a/oshw/vxworks/nicdrv.c
+++ b/oshw/vxworks/nicdrv.c
@@ -519,7 +519,7 @@ int ecx_outframe_red(ecx_portt *port, int idx)
       rval = ec_outfram_send(&(port->redport->pktDev), &(port->txbuf2), port->txbuflength2);
       if (rval <= 0)
       {
-         (*stack->rxbufstat)[idx] = EC_BUF_EMPTY;
+         port->redport->rxbufstat[idx] = EC_BUF_EMPTY;
       }
    }   
    

--- a/oshw/win32/nicdrv.c
+++ b/oshw/win32/nicdrv.c
@@ -594,11 +594,6 @@ int ecx_srconfirm(ecx_portt *port, int idx, int timeout)
       wkc = ecx_waitinframe_red(port, idx, &timer2);
    /* wait for answer with WKC>=0 or otherwise retry until timeout */
    } while ((wkc <= EC_NOFRAME) && !osal_timer_is_expired (&timer1));
-   /* if nothing received, clear buffer index status so it can be used again */
-   if (wkc <= EC_NOFRAME)
-   {
-      ecx_setbufstat(port, idx, EC_BUF_EMPTY);
-   }
 
    return wkc;
 }


### PR DESCRIPTION
Remove "extra" clear buffer on lost frame in the nic driver, it is done unconditional by the thread/user who allocated the buffer.

I've run win32  simpletest sync processdata and async sdo reads