### PR TITLE
Add possibiliy to set endian target by hardware layer

### DIFF
--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -23,14 +23,16 @@ extern "C"
 {
 #endif
 
-/** Define Little or Big endian target */
-#define EC_LITTLE_ENDIAN
-
 /** define EC_VER1 if version 1 default context and functions are needed
  * comment if application uses only ecx_ functions and own context */
 #define EC_VER1
 
 #include "osal.h"
+
+/** Define little endian target by default if no endian is set */
+#if !defined(EC_LITTLE_ENDIAN) && !defined(EC_BIG_ENDIAN)
+#   define EC_LITTLE_ENDIAN
+#endif
 
 /** return value general error */
 #define EC_ERROR           -3


### PR DESCRIPTION
Now it is possible to set a EC_LITTLE_ENDIAN or EC_BIG_ENDIAN in the
osal_defs.h file or by compile option. If no endian is defined, the default
EC_LITTLE_ENDIAN is used.