### PR TITLE
fix warning with strncpy on newer GCC's

### DIFF
--- a/oshw/linux/oshw.c
+++ b/oshw/linux/oshw.c
@@ -42,7 +42,6 @@ uint16 oshw_ntohs(uint16 network)
 ec_adaptert * oshw_find_adapters(void)
 {
    int i;
-   int string_len;
    struct if_nameindex *ids;
    ec_adaptert * adapter;
    ec_adaptert * prev_adapter;
@@ -75,15 +74,10 @@ ec_adaptert * oshw_find_adapters(void)
 
       if (ids[i].if_name)
       {
-          string_len = strlen(ids[i].if_name);
-          if (string_len > (EC_MAXLEN_ADAPTERNAME - 1))
-          {
-             string_len = EC_MAXLEN_ADAPTERNAME - 1;
-          }
-          strncpy(adapter->name, ids[i].if_name,string_len);
-          adapter->name[string_len] = '\0';
-          strncpy(adapter->desc, ids[i].if_name,string_len);
-          adapter->desc[string_len] = '\0';
+          strncpy(adapter->name, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->name[EC_MAXLEN_ADAPTERNAME-1] = '\0';
+          strncpy(adapter->desc, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->desc[EC_MAXLEN_ADAPTERNAME-1] = '\0';
       }
       else
       {

--- a/oshw/macosx/oshw.c
+++ b/oshw/macosx/oshw.c
@@ -42,7 +42,6 @@ uint16 oshw_ntohs(uint16 network)
 ec_adaptert * oshw_find_adapters(void)
 {
    int i;
-   int string_len;
    struct if_nameindex *ids;
    ec_adaptert * adapter;
    ec_adaptert * prev_adapter;
@@ -70,20 +69,15 @@ ec_adaptert * oshw_find_adapters(void)
          ret_adapter = adapter;
       }
 
-      /* fetch description and name, in Linux we use the same on both */
+      /* fetch description and name, in macosx we use the same on both */
       adapter->next = NULL;
 
       if (ids[i].if_name)
       {
-          string_len = strlen(ids[i].if_name);
-          if (string_len > (EC_MAXLEN_ADAPTERNAME - 1))
-          {
-             string_len = EC_MAXLEN_ADAPTERNAME - 1;
-          }
-          strncpy(adapter->name, ids[i].if_name,string_len);
-          adapter->name[string_len] = '\0';
-          strncpy(adapter->desc, ids[i].if_name,string_len);
-          adapter->desc[string_len] = '\0';
+          strncpy(adapter->name, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->name[EC_MAXLEN_ADAPTERNAME-1] = '\0';
+          strncpy(adapter->desc, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->desc[EC_MAXLEN_ADAPTERNAME-1] = '\0';
       }
       else
       {

--- a/oshw/rtems/oshw.c
+++ b/oshw/rtems/oshw.c
@@ -42,7 +42,6 @@ uint16 oshw_ntohs(uint16 network)
 ec_adaptert * oshw_find_adapters(void)
 {
    int i;
-   int string_len;
    struct if_nameindex *ids;
    ec_adaptert * adapter;
    ec_adaptert * prev_adapter;
@@ -70,20 +69,15 @@ ec_adaptert * oshw_find_adapters(void)
          ret_adapter = adapter;
       }
 
-      /* fetch description and name, in Linux we use the same on both */
+      /* fetch description and name, in rtems we use the same on both */
       adapter->next = NULL;
 
       if (ids[i].if_name)
       {
-          string_len = strlen(ids[i].if_name);
-          if (string_len > (EC_MAXLEN_ADAPTERNAME - 1))
-          {
-             string_len = EC_MAXLEN_ADAPTERNAME - 1;
-          }
-          strncpy(adapter->name, ids[i].if_name,string_len);
-          adapter->name[string_len] = '\0';
-          strncpy(adapter->desc, ids[i].if_name,string_len);
-          adapter->desc[string_len] = '\0';
+          strncpy(adapter->name, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->name[EC_MAXLEN_ADAPTERNAME-1] = '\0';
+          strncpy(adapter->desc, ids[i].if_name, EC_MAXLEN_ADAPTERNAME);
+          adapter->desc[EC_MAXLEN_ADAPTERNAME-1] = '\0';
       }
       else
       {

--- a/oshw/win32/oshw.c
+++ b/oshw/win32/oshw.c
@@ -42,7 +42,6 @@ ec_adaptert * oshw_find_adapters (void)
    ec_adaptert * prev_adapter;
    ec_adaptert * ret_adapter = NULL;
    char errbuf[PCAP_ERRBUF_SIZE];
-   size_t string_len;
 
    /* find all devices */
    if (pcap_findalldevs(&alldevs, errbuf) == -1)
@@ -73,13 +72,8 @@ ec_adaptert * oshw_find_adapters (void)
       adapter->next = NULL;
       if (d->name)
       {
-         string_len = strlen(d->name);
-         if (string_len > (EC_MAXLEN_ADAPTERNAME - 1))
-         {
-            string_len = EC_MAXLEN_ADAPTERNAME - 1;
-         }
-         strncpy(adapter->name, d->name,string_len);
-         adapter->name[string_len] = '\0';
+         strncpy(adapter->name, d->name, EC_MAXLEN_ADAPTERNAME);
+         adapter->name[EC_MAXLEN_ADAPTERNAME-1] = '\0';
       }
       else
       {
@@ -87,13 +81,8 @@ ec_adaptert * oshw_find_adapters (void)
       }
       if (d->description)
       {
-         string_len = strlen(d->description);
-         if (string_len > (EC_MAXLEN_ADAPTERNAME - 1))
-         {
-            string_len = EC_MAXLEN_ADAPTERNAME - 1;
-         }
-         strncpy(adapter->desc, d->description,string_len);
-         adapter->desc[string_len] = '\0';
+         strncpy(adapter->desc, d->description, EC_MAXLEN_ADAPTERNAME);
+         adapter->desc[EC_MAXLEN_ADAPTERNAME-1] = '\0';
       }
       else
       {


### PR DESCRIPTION
    fix warning with strncpy on newer GCC versions
    
    strncpy should not be called with a "length" parameter which is based on
    the source string since it negates the benefits of using strncpy. this
    patch fixes the warning for linux, macosx and rtems
    
    Fixes #346
