### PR TITLE
run on newer gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+jobs:
+  include:
+    - dist: xenial
+    - dist: bionic
+    - os: osx
+
 language: c
 
 script:


### PR DESCRIPTION
this patch adds building on ubuntu bionic that has a newer gcc while
keeping ubuntu xenial (default on travis-ci)