### PR TITLE
assert is removed from macos version of nicdrv.c

### DIFF
--- a/oshw/macosx/nicdrv.c
+++ b/oshw/macosx/nicdrv.c
@@ -440,7 +440,6 @@ int ecx_inframe(ecx_portt *port, int idx, int stacknumber)
                }
                else
                {
-		          assert(0);
                   /* strange things happened */
                }
             }


### PR DESCRIPTION
As discussed in [Issue #392](https://github.com/OpenEtherCATsociety/SOEM/issues/392), this assert only exists for macos and is an overkill. Removing it should not affect anything. On the contrary, for my use case, it eliminates a huge headache.