### PR TITLE
Revert "EoE and Distributed clock fixes"

### DIFF
--- a/soem/ethercatdc.c
+++ b/soem/ethercatdc.c
@@ -270,7 +270,7 @@ boolean ecx_configdc(ecx_contextt *context)
    ecx_BWR(context->port, 0, ECT_REG_DCTIME0, sizeof(ht), &ht, EC_TIMEOUTRET);  /* latch DCrecvTimeA of all slaves */
    mastertime = osal_current_time();
    mastertime.sec -= 946684800UL;  /* EtherCAT uses 2000-01-01 as epoch start instead of 1970-01-01 */
-   mastertime64 = (((uint64)mastertime.sec * 1000000000) + (uint64)mastertime.usec) * 1000;
+   mastertime64 = (((uint64)mastertime.sec * 1000000) + (uint64)mastertime.usec) * 1000;
    for (i = 1; i <= *(context->slavecount); i++)
    {
       context->slavelist[i].consumedports = context->slavelist[i].activeports;

--- a/soem/ethercateoe.h
+++ b/soem/ethercateoe.h
@@ -22,8 +22,6 @@ extern "C"
 #define EOE_DNS_NAME_LENGTH  32
 /** Ethernet address length not including VLAN */
 #define EOE_ETHADDR_LENGTH    6
-/** IPv4 address length */
-#define EOE_IP4_LENGTH        sizeof(uint32_t)
 
 #define EOE_MAKEU32(a,b,c,d) (((uint32_t)((a) & 0xff) << 24) | \
                             ((uint32_t)((b) & 0xff) << 16) | \


### PR DESCRIPTION
Reverts OpenEtherCATsociety/SOEM#431

The DC fix is incorrect, must have been out in the sun to long.
The original calulation is correct, (first sum up (s) * 1 000 000) + (us)) * 1000 for (ns)
One should belive in existing code

I'll create a new PR for the EoE fixes alone