### PR TITLE
Fix bug in ecx_readIDNmap(), Osize and Isize

### DIFF
--- a/soem/ethercatsoe.c
+++ b/soem/ethercatsoe.c
@@ -329,7 +329,7 @@ int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize)
       if ((wkc > 0) && (psize >= 4) && ((entries = etohs(SoEmapping.currentlength) / 2) > 0) && (entries <= EC_SOE_MAXMAPPING))
       {
          /* command word (uint16) is always mapped but not in list */
-         *Osize = 16;
+         *Osize += 16;
          for (itemcount = 0 ; itemcount < entries ; itemcount++)
          {
             psize = sizeof(SoEattribute);
@@ -348,7 +348,7 @@ int ecx_readIDNmap(ecx_contextt *context, uint16 slave, int *Osize, int *Isize)
       if ((wkc > 0) && (psize >= 4) && ((entries = etohs(SoEmapping.currentlength) / 2) > 0) && (entries <= EC_SOE_MAXMAPPING))
       {
          /* status word (uint16) is always mapped but not in list */
-         *Isize = 16;
+         *Isize += 16;
          for (itemcount = 0 ; itemcount < entries ; itemcount++)
          {
             psize = sizeof(SoEattribute);


### PR DESCRIPTION
Osize and Isize where reset to 16 at every new drive number, thus loosing all lower drive mapping data. Changed to add 16 to Osize and Isize.