### PR TITLE
Change include in ethercateoe.h

### DIFF
--- a/soem/ethercateoe.h
+++ b/soem/ethercateoe.h
@@ -16,7 +16,7 @@ extern "C"
 {
 #endif
 
-#include <ethercattype.h> 
+#include "ethercattype.h" 
 
 /* use maximum size for EOE mailbox data */
 #define EC_MAXEOEDATA EC_MAXMBX


### PR DESCRIPTION
A fix for issue #470.

GCC automatically searches a few default directories for `#include <>` statements. The current directory is not one of those.
By changing to `#include ""`, the current directory is searched for `ethercattype.h`.