### PR TITLE
Proposal: Add Userdata to ecx_context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ endif()
 
 set(SOEM_INCLUDE_INSTALL_DIR include/soem)
 set(SOEM_LIB_INSTALL_DIR lib)
-set(BUILD_TESTS TRUE)
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  set(BUILD_TESTS TRUE)
+else()
+  message(STATUS "SOEM: not building tests when built as dependency")
+  set(BUILD_TESTS FALSE)
+endif()
 
 if(WIN32)
   set(OS "win32")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ elseif(APPLE)
   set(OS_LIBS pthread pcap)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "rt-kernel")
   set(OS "rtk")
-  message("ARCH is ${ARCH}")
-  message("BSP is ${BSP}")
+  message(STATUS "ARCH is ${ARCH}")
+  message(STATUS "BSP is ${BSP}")
   include_directories(oshw/${OS}/${ARCH})
   file(GLOB OSHW_EXTRA_SOURCES oshw/${OS}/${ARCH}/*.c)
   set(OSHW_SOURCES "${OS_HW_SOURCES} ${OSHW_ARCHSOURCES}")
@@ -54,13 +54,13 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "rt-kernel")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format")
   set(OS_LIBS "-Wl,--start-group -l${BSP} -l${ARCH} -lkern -ldev -lsio -lblock -lfs -lusb -llwip -leth -li2c -lrtc -lcan -lnand -lspi -lnor -lpwm -ladc -ltrace -lc -lm -Wl,--end-group")
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "rtems")
-  message("Building for RTEMS")
+  message(STATUS "Building for RTEMS")
   set(OS "rtems")
   set(SOEM_LIB_INSTALL_DIR ${LIB_DIR})
   set(BUILD_TESTS FALSE)
 endif()
 
-message("OS is ${OS}")
+message(STATUS "OS is ${OS}")
 
 file(GLOB SOEM_SOURCES soem/*.c)
 file(GLOB OSAL_SOURCES osal/${OS}/*.c)
@@ -94,7 +94,7 @@ target_include_directories(soem
   $<INSTALL_INTERFACE:include/soem>
   )
 
-message("LIB_DIR: ${SOEM_LIB_INSTALL_DIR}")
+message(STATUS "LIB_DIR: ${SOEM_LIB_INSTALL_DIR}")
 
 install(TARGETS soem EXPORT soemConfig DESTINATION ${SOEM_LIB_INSTALL_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
-project(SOEM C)
+cmake_policy(SET CMP0048 NEW)
+project(SOEM
+    DESCRIPTION "Simple Open EtherCAT Master"
+    VERSION 1.4.0
+    LANGUAGES C)
 
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   # Default to installing in SOEM source directory

--- a/soem/ethercatmain.c
+++ b/soem/ethercatmain.c
@@ -118,7 +118,8 @@ ecx_contextt  ecx_context = {
     &ec_FMMU,           // .eepFMMU       =
     NULL,               // .FOEhook()
     NULL,               // .EOEhook()
-    0                   // .manualstatechange
+    0,                  // .manualstatechange
+    NULL,               // .userdata
 };
 #endif
 

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -426,6 +426,9 @@ struct ecx_context
    int            (*EOEhook)(ecx_contextt * context, uint16 slave, void * eoembx);
    /** flag to control legacy automatic state change or manual state change */
    int            manualstatechange;
+   /** userdata, promotes application configuration esp. in EC_VER2 with multiple 
+    * ec_context instances. Note: userdata memory is managed by application, not SOEM */
+   void           *userdata;
 };
 
 #ifdef EC_VER1


### PR DESCRIPTION
This PR adds 4 improvements:
* Adds `void* userdata` to `ecx_context` 
* Adds CMake `VERSION`, `DESCIPTION`, `LANGUAGES` to `project()`
* Changes CMake print outs from `message(...)` to `message(STATUS ...)` 
* Improves `BUILD_TESTS` logic when building SOEM as a dependency

The `userdata` pointer is useful for accessing user contexts to PO2SO callbacks without global variables. This is especially important when using `EC_VER2` to support multiple ecx_contexts in a single process.

The CMake improvements mainly quality-of-life improvements. If you'd like me to break these improvements into different PRs or wish to revert some of my CMake improvements please be my guest!