### PR TITLE
Check al_state after request

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -598,6 +598,7 @@ int ecx_config_init(ecx_contextt *context, uint8 usetable)
                ECT_REG_ALCTL,
                htoes(EC_STATE_PRE_OP | EC_STATE_ACK),
                EC_TIMEOUTRET3); /* set preop status */
+            (void)ecx_statecheck(context, slave, EC_STATE_PRE_OP, EC_TIMEOUTSTATE);
          }
       }
    }
@@ -1305,6 +1306,7 @@ int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group)
                   ECT_REG_ALCTL,
                   htoes(EC_STATE_SAFE_OP),
                   EC_TIMEOUTRET3); /* set safeop status */
+               (void)ecx_statecheck(context, slave, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE);
             }
             if (context->slavelist[slave].blockLRW)
             {
@@ -1449,6 +1451,7 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
                   ECT_REG_ALCTL,
                   htoes(EC_STATE_SAFE_OP),
                   EC_TIMEOUTRET3);
+               (void)ecx_statecheck(context, slave, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE);
             }
             if (context->slavelist[slave].blockLRW)
             {


### PR DESCRIPTION
I faced a race condition using SOEM/SOES in a simulated environment (that is, without real hardware for slave). The following race condition occasionally happens in `test/linux/firm_update/firm_update.c` which leads to firm_update failure:

```cpp
	    if ( ec_config_init(FALSE) > 0 )
		{
			printf("%d slaves found and configured.\n",ec_slavecount);

			printf("Request init state for slave %d\n", slave);
			ec_slave[slave].state = EC_STATE_INIT;
			ec_writestate(slave);

			/* wait for slave to reach INIT state */
			ec_statecheck(slave, EC_STATE_INIT,  EC_TIMEOUTSTATE * 4);
```

During `ec_config_init` SOEM requests transition to PRE_OP state without waiting. There is a possible situation when we reach the next lines with the transition to INIT state before the previous transition was actually handled by the slave. I added several `ecx_statecheck` to fix this and making SOEM not relying on the "slave's speed".


P.S.
CMakeLists.txt is missing in firm_update/ (I created my own). Is this intentional or it's a bug?