### PR TITLE
Adjust size of ec_EOE_t to max mailbox size

### DIFF
--- a/soem/ethercateoe.h
+++ b/soem/ethercateoe.h
@@ -16,10 +16,12 @@ extern "C"
 {
 #endif
 
-#include "ethercattype.h" 
+#include "ethercat.h"
 
-/* use maximum size for EOE mailbox data */
-#define EC_MAXEOEDATA EC_MAXMBX
+/* use maximum size for EOE mailbox data - mbxheader and 2x frameinfo */
+#define EC_MAXEOEDATA (EC_MAXMBX - (sizeof(ec_mbxheadert) +\
+                                    sizeof(uint16_t) +\
+                                    sizeof(uint16_t)))
 
 /** DNS length according to ETG 1000.6 */
 #define EOE_DNS_NAME_LENGTH  32


### PR DESCRIPTION
Consider size of mailbox header and frameinfo1 and 2 fields when calculating the data portion of ec_EOE_t

fix #514