### PR TITLE
Fix some UB cases. Closes #546

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -1474,7 +1474,10 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
       {
          if (!group || (group == context->slavelist[slave].group))
          {
-            context->slavelist[slave].inputs += context->grouplist[group].Obytes;
+            if(context->slavelist[slave].Ibits > 0)
+            {
+               context->slavelist[slave].inputs += context->grouplist[group].Obytes;
+            }
          }
       }
 

--- a/soem/ethercatmain.c
+++ b/soem/ethercatmain.c
@@ -349,7 +349,7 @@ uint8 ecx_siigetbyte(ecx_contextt *context, uint16 slave, uint16 address)
    {
       mapw = address >> 5;
       mapb = (uint16)(address - (mapw << 5));
-      if (context->esimap[mapw] & (uint32)(1 << mapb))
+      if (context->esimap[mapw] & (1U << mapb))
       {
          /* byte is already in buffer */
          retval = context->esibuf[address];
@@ -380,7 +380,7 @@ uint8 ecx_siigetbyte(ecx_contextt *context, uint16 slave, uint16 address)
          for(lp = 0 ; lp < cnt ; lp++)
          {
             /* set bitmap for each byte that is read */
-            context->esimap[mapw] |= (1 << mapb);
+            context->esimap[mapw] |= (1U << mapb);
             mapb++;
             if (mapb > 31)
             {


### PR DESCRIPTION
There are two cases of UB that are fixed in this commit.

1. In ethercatmain.c, there are two left shifts of 31:

    (1 << 31)

Because 1 is a signed int by default, the result cannot be represented
in an int. The fix is to explicitly make the 1 unsigned.

2. In ethercatconfig.c, for slaves that have no inputs, the code would
   apply an offset to a NULL pointer. The fix is to test that the slave
   has inputs available before applying the offset.

Both cases were found by clang with the help of UBSan.