### PR TITLE
Examples: show avaialable adapters if not specified

### DIFF
--- a/test/linux/eepromtool/eepromtool.c
+++ b/test/linux/eepromtool/eepromtool.c
@@ -456,6 +456,8 @@ int main(int argc, char *argv[])
    }
    else
    {
+      ec_adaptert * adapter = NULL;
+
       printf("Usage: eepromtool ifname slave OPTION fname|alias\n");
       printf("ifname = eth0 for example\n");
       printf("slave = slave number in EtherCAT order 1..n\n");
@@ -465,6 +467,15 @@ int main(int argc, char *argv[])
       printf("    -ri     read EEPROM, output Intel Hex format\n");
       printf("    -w      write EEPROM, input binary format\n");
       printf("    -wi     write EEPROM, input Intel Hex format\n");
+
+      printf ("\nAvailable adapters:\n");
+      adapter = ec_find_adapters ();
+      while (adapter != NULL)
+      {
+         printf ("    - %s  (%s)\n", adapter->name, adapter->desc);
+         adapter = adapter->next;
+      }
+      ec_free_adapters(adapter);
    }
 
    printf("End program\n");

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -234,7 +234,17 @@ int main(int argc, char *argv[])
    }
    else
    {
+      ec_adaptert * adapter = NULL;
       printf("Usage: simple_test ifname1\nifname = eth0 for example\n");
+
+      printf ("\nAvailable adapters:\n");
+      adapter = ec_find_adapters ();
+      while (adapter != NULL)
+      {
+         printf ("    - %s  (%s)\n", adapter->name, adapter->desc);
+         adapter = adapter->next;
+      }
+      ec_free_adapters(adapter);
    }
 
    printf("End program\n");

--- a/test/linux/slaveinfo/slaveinfo.c
+++ b/test/linux/slaveinfo/slaveinfo.c
@@ -643,6 +643,7 @@ int main(int argc, char *argv[])
          printf ("Description : %s, Device to use for wpcap: %s\n", adapter->desc,adapter->name);
          adapter = adapter->next;
       }
+      ec_free_adapters(adapter);
    }
 
    printf("End program\n");

--- a/test/simple_ng/simple_ng.c
+++ b/test/simple_ng/simple_ng.c
@@ -286,8 +286,18 @@ main(int argc, char *argv[])
     Fieldbus fieldbus;
 
     if (argc != 2) {
+        ec_adaptert * adapter = NULL;
         printf("Usage: simple_ng IFNAME1\n"
                "IFNAME1 is the NIC interface name, e.g. 'eth0'\n");
+
+        printf("\nAvailable adapters:\n");
+        adapter = ec_find_adapters();
+        while (adapter != NULL)
+        {
+            printf("    - %s  (%s)\n", adapter->name, adapter->desc);
+            adapter = adapter->next;
+        }
+        ec_free_adapters(adapter);
         return 1;
     }
 


### PR DESCRIPTION
This patch shows available adapters if not specified on the commandline for the example programs. The functionality was already available for `simple_test` but not for the others.