### PR TITLE
Update build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,9 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
           - macos-latest
           - windows-latest
     steps:


### PR DESCRIPTION
Ubuntu 16.04 is now deprecated. Remove it and add ubuntu-latest.