### PR TITLE
Bump cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
-cmake_policy(SET CMP0048 NEW)
 project(SOEM
     DESCRIPTION "Simple Open EtherCAT Master"
     VERSION 1.4.0

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BUILDING
 Prerequisites for all platforms
 -------------------------------
 
- * CMake 2.8.0 or later
+ * CMake 3.9 or later
 
 
 Windows (Visual Studio)


### PR DESCRIPTION
Bump CMake version to 3.9, which the oldest version supporting the
project DESCRIPTION option (see
https://cmake.org/cmake/help/latest/command/project.html#command:project),
which was introduced by commit 59821cb.

CMake policy CMP0048 is set to NEW by default since 3.0 and can be
removed.

Fixes #559, fixes #512