### PR TITLE
avoid 'maybe used unitialized' warnings

### DIFF
--- a/oshw/linux/oshw.c
+++ b/oshw/linux/oshw.c
@@ -44,7 +44,7 @@ ec_adaptert * oshw_find_adapters(void)
    int i;
    struct if_nameindex *ids;
    ec_adaptert * adapter;
-   ec_adaptert * prev_adapter;
+   ec_adaptert * prev_adapter = NULL;
    ec_adaptert * ret_adapter = NULL;
 
 
@@ -60,7 +60,7 @@ ec_adaptert * oshw_find_adapters(void)
        * adapter.
        * Else save as pointer to return.
        */
-      if (i)
+      if (prev_adapter)
       {
          prev_adapter->next = adapter;
       }

--- a/soem/ethercateoe.c
+++ b/soem/ethercateoe.c
@@ -420,6 +420,8 @@ int ecx_EOErecv(ecx_contextt *context, uint16 slave, uint8 port, int * psize, vo
    NotLast = TRUE;
    buffersize = *psize;
    rxfragmentno = 0;
+   rxframeno = 0xff;
+   rxframeoffset = 0;
    
    /* Hang for a while if nothing is in */
    wkc = ecx_mbxreceive(context, slave, (ec_mbxbuft *)&MbxIn, timeout);
@@ -446,7 +448,6 @@ int ecx_EOErecv(ecx_contextt *context, uint16 slave, uint8 port, int * psize, vo
 
          if (rxfragmentno == 0)
          {
-            rxframeoffset = 0;
             rxframeno = EOE_HDR_FRAME_NO_GET(frameinfo2);
             rxframesize = (EOE_HDR_FRAME_OFFSET_GET(frameinfo2) << 5);
             if (rxframesize > buffersize)


### PR DESCRIPTION
gcc : -Wmaybe-uninitialized or -Wuninitialized

Enable consuming projects to build with strict settings.

I believe the fixes should be safe, let me know if adjustments are required ;-)