### PR TITLE
const correctness in coe functions

### DIFF
--- a/soem/ethercatcoe.c
+++ b/soem/ethercatcoe.c
@@ -584,7 +584,7 @@ int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber, int psize
 
 /** CoE TxPDO read remote request, blocking.
  *
- * A RxPDO download request is issued.
+ * A TxPDO download request is issued.
  *
  * @param[in]  context       = context struct
  * @param[in]  slave         = Slave number
@@ -1388,7 +1388,7 @@ int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber, int psize, const void *p)
 
 /** CoE TxPDO read remote request, blocking.
  *
- * A RxPDO download request is issued.
+ * A TxPDO download request is issued.
  *
  * @param[in]  slave         = Slave number
  * @param[in]  TxPDOnumber   = Related TxPDO number

--- a/soem/ethercatcoe.c
+++ b/soem/ethercatcoe.c
@@ -328,14 +328,14 @@ int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subinde
  * @return Workcounter from last slave response
  */
 int ecx_SDOwrite(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIndex,
-                boolean CA, int psize, void *p, int Timeout)
+                 boolean CA, int psize, const void *p, int Timeout)
 {
    ec_SDOt *SDOp, *aSDOp;
    int wkc, maxdata, framedatasize;
    ec_mbxbuft MbxIn, MbxOut;
    uint8 cnt, toggle;
    boolean  NotLast;
-   uint8 *hp;
+   const uint8 *hp;
 
    ec_clearmbx(&MbxIn);
    /* Empty slave out mailbox if something is in. Timeout set to 0 */
@@ -548,7 +548,7 @@ int ecx_SDOwrite(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubInd
  * @param[out] p             = Pointer to PDO buffer
  * @return Workcounter from last slave response
  */
-int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber, int psize, void *p)
+int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber, int psize, const void *p)
 {
    ec_SDOt *SDOp;
    int wkc, maxdata, framedatasize;
@@ -1365,7 +1365,7 @@ int ec_SDOread(uint16 slave, uint16 index, uint8 subindex,
  * @see ecx_SDOwrite
  */
 int ec_SDOwrite(uint16 Slave, uint16 Index, uint8 SubIndex,
-                boolean CA, int psize, void *p, int Timeout)
+                boolean CA, int psize, const void *p, int Timeout)
 {
    return ecx_SDOwrite(&ecx_context, Slave, Index, SubIndex, CA, psize, p, Timeout);
 }
@@ -1381,7 +1381,7 @@ int ec_SDOwrite(uint16 Slave, uint16 Index, uint8 SubIndex,
  * @return Workcounter from last slave response
  * @see ecx_RxPDO
  */
-int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber, int psize, void *p)
+int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber, int psize, const void *p)
 {
    return ecx_RxPDO(&ecx_context, Slave, RxPDOnumber, psize, p);
 }

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -63,8 +63,8 @@ void ec_SDOerror(uint16 Slave, uint16 Index, uint8 SubIdx, int32 AbortCode);
 int ec_SDOread(uint16 slave, uint16 index, uint8 subindex,
                       boolean CA, int *psize, void *p, int timeout);
 int ec_SDOwrite(uint16 Slave, uint16 Index, uint8 SubIndex,
-    boolean CA, int psize, void *p, int Timeout);
-int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber , int psize, void *p);
+                boolean CA, int psize, const void *p, int Timeout);
+int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber , int psize, const void *p);
 int ec_TxPDO(uint16 slave, uint16 TxPDOnumber , int *psize, void *p, int timeout);
 int ec_readPDOmap(uint16 Slave, uint32 *Osize, uint32 *Isize);
 int ec_readPDOmapCA(uint16 Slave, int Thread_n, uint32 *Osize, uint32 *Isize);
@@ -78,8 +78,8 @@ void ecx_SDOerror(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubId
 int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex,
                       boolean CA, int *psize, void *p, int timeout);
 int ecx_SDOwrite(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIndex,
-    boolean CA, int psize, void *p, int Timeout);
-int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber , int psize, void *p);
+                 boolean CA, int psize, const void *p, int Timeout);
+int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber , int psize, const void *p);
 int ecx_TxPDO(ecx_contextt *context, uint16 slave, uint16 TxPDOnumber , int *psize, void *p, int timeout);
 int ecx_readPDOmap(ecx_contextt *context, uint16 Slave, uint32 *Osize, uint32 *Isize);
 int ecx_readPDOmapCA(ecx_contextt *context, uint16 Slave, int Thread_n, uint32 *Osize, uint32 *Isize);

--- a/soem/ethercatcoe.h
+++ b/soem/ethercatcoe.h
@@ -61,7 +61,7 @@ typedef struct
 #ifdef EC_VER1
 void ec_SDOerror(uint16 Slave, uint16 Index, uint8 SubIdx, int32 AbortCode);
 int ec_SDOread(uint16 slave, uint16 index, uint8 subindex,
-                      boolean CA, int *psize, void *p, int timeout);
+               boolean CA, int *psize, void *p, int timeout);
 int ec_SDOwrite(uint16 Slave, uint16 Index, uint8 SubIndex,
                 boolean CA, int psize, const void *p, int Timeout);
 int ec_RxPDO(uint16 Slave, uint16 RxPDOnumber , int psize, const void *p);
@@ -76,7 +76,7 @@ int ec_readOE(uint16 Item, ec_ODlistt *pODlist, ec_OElistt *pOElist);
 
 void ecx_SDOerror(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIdx, int32 AbortCode);
 int ecx_SDOread(ecx_contextt *context, uint16 slave, uint16 index, uint8 subindex,
-                      boolean CA, int *psize, void *p, int timeout);
+                boolean CA, int *psize, void *p, int timeout);
 int ecx_SDOwrite(ecx_contextt *context, uint16 Slave, uint16 Index, uint8 SubIndex,
                  boolean CA, int psize, const void *p, int Timeout);
 int ecx_RxPDO(ecx_contextt *context, uint16 Slave, uint16 RxPDOnumber , int psize, const void *p);


### PR DESCRIPTION
- The data pointer in SDOWrite and RxPDO can be made const.
- type in docs