### PR TITLE
Added config_map_aligned to use byte aligned outputs and inputs

### DIFF
--- a/soem/ethercatconfig.h
+++ b/soem/ethercatconfig.h
@@ -23,8 +23,10 @@ extern "C"
 int ec_config_init(uint8 usetable);
 int ec_config_map(void *pIOmap);
 int ec_config_overlap_map(void *pIOmap);
+int ec_config_map_aligned(void *pIOmap);
 int ec_config_map_group(void *pIOmap, uint8 group);
 int ec_config_overlap_map_group(void *pIOmap, uint8 group);
+int ec_config_map_group_aligned(void *pIOmap, uint8 group);
 int ec_config(uint8 usetable, void *pIOmap);
 int ec_config_overlap(uint8 usetable, void *pIOmap);
 int ec_recover_slave(uint16 slave, int timeout);
@@ -34,6 +36,7 @@ int ec_reconfig_slave(uint16 slave, int timeout);
 int ecx_config_init(ecx_contextt *context, uint8 usetable);
 int ecx_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 group);
+int ecx_config_map_group_aligned(ecx_contextt *context, void *pIOmap, uint8 group);
 int ecx_recover_slave(ecx_contextt *context, uint16 slave, int timeout);
 int ecx_reconfig_slave(ecx_contextt *context, uint16 slave, int timeout);
 

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -24,6 +24,7 @@ boolean needlf;
 volatile int wkc;
 boolean inOP;
 uint8 currentgroup = 0;
+boolean forceByteAlignment = FALSE;
 
 void simpletest(char *ifname)
 {
@@ -44,7 +45,14 @@ void simpletest(char *ifname)
       {
          printf("%d slaves found and configured.\n",ec_slavecount);
 
-         ec_config_map(&IOmap);
+         if (forceByteAlignment)
+         {
+            ec_config_map_aligned(&IOmap);
+         }
+         else
+         {
+            ec_config_map(&IOmap);
+         }
 
          ec_configdc();
 


### PR DESCRIPTION
I noticed that when using config_overlap,map that the outputs and inputs are byte aligned.
I added an option to force byte alignment when performing the IO Mapping in the non overlapping case, and I adapted the simple_test.

Tested it with two EL2624 terminals.