### PR TITLE
Return the "file not found" error for ecx_FOEread() through wkc

### DIFF
--- a/soem/ethercatfoe.c
+++ b/soem/ethercatfoe.c
@@ -163,7 +163,15 @@ int ecx_FOEread(ecx_contextt *context, uint16 slave, char *filename, uint32 pass
                   if(aFOEp->OpCode == ECT_FOE_ERROR)
                   {
                      /* FoE error */
-                     wkc = -EC_ERR_TYPE_FOE_ERROR;
+                     if (aFOEp->ErrorCode == 0x8001)
+                     {
+                        wkc = -EC_ERR_TYPE_FOE_FILE_NOTFOUND;
+                     }
+                     else
+                     {
+                        wkc = -EC_ERR_TYPE_FOE_ERROR;
+                     }
+                     break;
                   }
                   else
                   {


### PR DESCRIPTION
The "file not found" error is the most significant error that can be returned from the above function as it can affect and guide the work flow, so it makes sense to have it returned in some way. Since the same error has already been processed and returned in the ecx_FOEwrite() function, there is no reason not to process it and return it in the ecx_FOEread() function in the exact same way.
The good thing about this change is that it adds a lot of flexibility cheaply, since it doesn't require full support for all FoE errors.