### PR TITLE
Using unicast MAC address as source address

### DIFF
--- a/oshw/rtk/nicdrv.c
+++ b/oshw/rtk/nicdrv.c
@@ -61,7 +61,7 @@ enum
  * differentiate the route the packet traverses through the EtherCAT
  * segment. This is needed to find out the packet flow in redundant
  * configurations. */
-const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+const uint16 priMAC[3] = { 0x0001, 0x0101, 0x0101 };
 /** Secondary source MAC address used for EtherCAT. */
 const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
 

--- a/oshw/vxworks/nicdrv.c
+++ b/oshw/vxworks/nicdrv.c
@@ -90,7 +90,7 @@ enum
  * differentiate the route the packet traverses through the EtherCAT
  * segment. This is needed to find out the packet flow in redundant
  * configurations. */
-const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+const uint16 priMAC[3] = { 0x0001, 0x0101, 0x0101 };
 /** Secondary source MAC address used for EtherCAT. */
 const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
 

--- a/oshw/win32/nicdrv.c
+++ b/oshw/win32/nicdrv.c
@@ -61,7 +61,7 @@ enum
  * differentiate the route the packet traverses through the EtherCAT
  * segment. This is needed to fund out the packet flow in redundant
  * configurations. */
-const uint16 priMAC[3] = { 0x0101, 0x0101, 0x0101 };
+const uint16 priMAC[3] = { 0x0001, 0x0101, 0x0101 };
 /** Secondary source MAC address used for EtherCAT. */
 const uint16 secMAC[3] = { 0x0404, 0x0404, 0x0404 };
 


### PR DESCRIPTION
Using Multicast address as source MAC address causes problems when SOEM is used with hyper-v vmswitch. hyper-v vmswitch doesn't forward the packet if source MAC address is multicast