### PR TITLE
Add additional check of fully reading (line 926)

### DIFF
--- a/soem/ethercatcoe.c
+++ b/soem/ethercatcoe.c
@@ -923,6 +923,11 @@ int ecx_readPDOmapCA(ecx_contextt *context, uint16 Slave, int Thread_n, uint32 *
    /* read SyncManager Communication Type object count Complete Access*/
    wkc = ecx_SDOread(context, Slave, ECT_SDO_SMCOMMTYPE, 0x00, TRUE, &rdl,
          &(context->SMcommtype[Thread_n]), EC_TIMEOUTRXM);
+
+   /* check of fully reading */
+   if ((wkc > 0) && (rdl!=sizeof(ec_SMcommtypet)))
+      wkc = 0;
+
    /* positive result from slave ? */
    if ((wkc > 0) && (context->SMcommtype[Thread_n].n > 2))
    {


### PR DESCRIPTION
My controller Elmo Gold twitter (man: 0x0000009a  id: 0x00030924) returns a different value than reading SyncManager Communication Type by  Complete Access. 
I add an extra check and return 0 for ecx_map_coe_soe to work correctly.

![image](https://user-images.githubusercontent.com/6222686/235617757-98ca2058-ab00-4777-8960-4965e24c292d.png)
