### PR TITLE
Remove variable for unused parameter.

### DIFF
--- a/test/linux/eoe_test/eoe_test.c
+++ b/test/linux/eoe_test/eoe_test.c
@@ -404,8 +404,8 @@ int main(int argc, char *argv[])
    if (argc > 1)
    {
       /* create thread to handle slave error handling in OP */
-//      pthread_create( &thread1, NULL, (void *) &ecatcheck, (void*) &ctime);
-      osal_thread_create(&thread1, 128000, &ecatcheck, (void*) &ctime);
+//      pthread_create( &thread1, NULL, (void *) &ecatcheck, NULL);
+      osal_thread_create(&thread1, 128000, &ecatcheck, NULL);
 
       /* start cyclic part */
       teststarter(argv[1]);

--- a/test/linux/eoe_test/eoe_test.c
+++ b/test/linux/eoe_test/eoe_test.c
@@ -404,7 +404,6 @@ int main(int argc, char *argv[])
    if (argc > 1)
    {
       /* create thread to handle slave error handling in OP */
-//      pthread_create( &thread1, NULL, (void *) &ecatcheck, NULL);
       osal_thread_create(&thread1, 128000, &ecatcheck, NULL);
 
       /* start cyclic part */

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -235,8 +235,8 @@ int main(int argc, char *argv[])
    if (argc > 1)
    {
       /* create thread to handle slave error handling in OP */
-//      pthread_create( &thread1, NULL, (void *) &ecatcheck, (void*) &ctime);
-      osal_thread_create(&thread1, 128000, &ecatcheck, (void*) &ctime);
+//      pthread_create( &thread1, NULL, (void *) &ecatcheck, NULL);
+      osal_thread_create(&thread1, 128000, &ecatcheck, NULL);
       /* start cyclic part */
       simpletest(argv[1]);
    }

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -235,7 +235,6 @@ int main(int argc, char *argv[])
    if (argc > 1)
    {
       /* create thread to handle slave error handling in OP */
-//      pthread_create( &thread1, NULL, (void *) &ecatcheck, NULL);
       osal_thread_create(&thread1, 128000, &ecatcheck, NULL);
       /* start cyclic part */
       simpletest(argv[1]);

--- a/test/win32/simple_test/simple_test.c
+++ b/test/win32/simple_test/simple_test.c
@@ -350,7 +350,7 @@ int main(int argc, char *argv[])
    if (argc > 1)
    {
       /* create thread to handle slave error handling in OP */
-      osal_thread_create(&thread1, 128000, &ecatcheck, (void*) &ctime);
+      osal_thread_create(&thread1, 128000, &ecatcheck, NULL);
       strcpy(ifbuf, argv[1]);
       /* start cyclic part */
       simpletest(ifbuf);


### PR DESCRIPTION
ecatcheck doesn't use the parameter sent to it. 
On system with no ctime, ctime caused undeclared identifier when building.
Replacing ctime with NULL.