### PR TITLE
Allow FoE write of 0byte file

### DIFF
--- a/soem/ethercatfoe.c
+++ b/soem/ethercatfoe.c
@@ -214,7 +214,7 @@ int ecx_FOEwrite(ecx_contextt *context, uint16 slave, char *filename, uint32 pas
    ec_clearmbx(&MbxOut);
    aFOEp = (ec_FOEt *)&MbxIn;
    FOEp = (ec_FOEt *)&MbxOut;
-   dofinalzero = FALSE;
+   dofinalzero = TRUE;
    fnsize = (uint16)strlen(filename);
    maxdata = context->slavelist[slave].mbx_l - 12;
    if (fnsize > maxdata)


### PR DESCRIPTION
If FoE write of a file is done, no check
of incoming size is performed. If the
file is 0byte, a FoE Write Request is
sent but no ACK since dofinalzero
is initialized to FALSE.

fixes #766