### PR TITLE
tests: fix linked list leaks

### DIFF
--- a/test/linux/eepromtool/eepromtool.c
+++ b/test/linux/eepromtool/eepromtool.c
@@ -457,6 +457,7 @@ int main(int argc, char *argv[])
    else
    {
       ec_adaptert * adapter = NULL;
+      ec_adaptert * head = NULL;
 
       printf("Usage: eepromtool ifname slave OPTION fname|alias\n");
       printf("ifname = eth0 for example\n");
@@ -469,13 +470,13 @@ int main(int argc, char *argv[])
       printf("    -wi     write EEPROM, input Intel Hex format\n");
 
       printf ("\nAvailable adapters:\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("    - %s  (%s)\n", adapter->name, adapter->desc);
          adapter = adapter->next;
       }
-      ec_free_adapters(adapter);
+      ec_free_adapters(head);
    }
 
    printf("End program\n");

--- a/test/linux/simple_test/simple_test.c
+++ b/test/linux/simple_test/simple_test.c
@@ -242,16 +242,17 @@ int main(int argc, char *argv[])
    else
    {
       ec_adaptert * adapter = NULL;
+      ec_adaptert * head = NULL;
       printf("Usage: simple_test ifname1\nifname = eth0 for example\n");
 
       printf ("\nAvailable adapters:\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("    - %s  (%s)\n", adapter->name, adapter->desc);
          adapter = adapter->next;
       }
-      ec_free_adapters(adapter);
+      ec_free_adapters(head);
    }
 
    printf("End program\n");

--- a/test/linux/slaveinfo/slaveinfo.c
+++ b/test/linux/slaveinfo/slaveinfo.c
@@ -699,6 +699,7 @@ char ifbuf[1024];
 int main(int argc, char *argv[])
 {
    ec_adaptert * adapter = NULL;
+   ec_adaptert * head = NULL;
    printf("SOEM (Simple Open EtherCAT Master)\nSlaveinfo\n");
 
    if (argc > 1)
@@ -714,13 +715,13 @@ int main(int argc, char *argv[])
       printf("Usage: slaveinfo ifname [options]\nifname = eth0 for example\nOptions :\n -sdo : print SDO info\n -map : print mapping\n");
 
       printf ("Available adapters\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("Description : %s, Device to use for wpcap: %s\n", adapter->desc,adapter->name);
          adapter = adapter->next;
       }
-      ec_free_adapters(adapter);
+      ec_free_adapters(head);
    }
 
    printf("End program\n");

--- a/test/simple_ng/simple_ng.c
+++ b/test/simple_ng/simple_ng.c
@@ -287,17 +287,18 @@ main(int argc, char *argv[])
 
     if (argc != 2) {
         ec_adaptert * adapter = NULL;
+        ec_adaptert * head = NULL;
         printf("Usage: simple_ng IFNAME1\n"
                "IFNAME1 is the NIC interface name, e.g. 'eth0'\n");
 
         printf("\nAvailable adapters:\n");
-        adapter = ec_find_adapters();
+        head = adapter = ec_find_adapters();
         while (adapter != NULL)
         {
             printf("    - %s  (%s)\n", adapter->name, adapter->desc);
             adapter = adapter->next;
         }
-        ec_free_adapters(adapter);
+        ec_free_adapters(head);
         return 1;
     }
 

--- a/test/win32/eepromtool/eepromtool.c
+++ b/test/win32/eepromtool/eepromtool.c
@@ -349,6 +349,7 @@ void eepromtool(char *ifname, int slave, int mode, char *fname)
 int main(int argc, char *argv[])
 {
    ec_adaptert * adapter = NULL;
+   ec_adaptert * head = NULL;
    printf("SOEM (Simple Open EtherCAT Master)\nEEPROM tool\n");
 
    if (argc > 4)
@@ -374,12 +375,13 @@ int main(int argc, char *argv[])
       printf("    -wi     write EEPROM, input Intel Hex format\n");
    	/* Print the list */
       printf ("Available adapters\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("Description : %s, Device to use for wpcap: %s\n", adapter->desc,adapter->name);
          adapter = adapter->next;
       }
+      ec_free_adapters(adapter);
    }
 
    printf("End program\n");

--- a/test/win32/simple_test/simple_test.c
+++ b/test/win32/simple_test/simple_test.c
@@ -345,6 +345,7 @@ char ifbuf[1024];
 int main(int argc, char *argv[])
 {
    ec_adaptert * adapter = NULL;
+   ec_adaptert * head = NULL;
    printf("SOEM (Simple Open EtherCAT Master)\nSimple test\n");
 
    if (argc > 1)
@@ -360,12 +361,13 @@ int main(int argc, char *argv[])
       printf("Usage: simple_test ifname1\n");
    	/* Print the list */
       printf ("Available adapters\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("Description : %s, Device to use for wpcap: %s\n", adapter->desc,adapter->name);
          adapter = adapter->next;
       }
+      ec_free_adapters(adapter);
    }
 
    printf("End program\n");

--- a/test/win32/slaveinfo/slaveinfo.c
+++ b/test/win32/slaveinfo/slaveinfo.c
@@ -618,6 +618,7 @@ char ifbuf[1024];
 int main(int argc, char *argv[])
 {
    ec_adaptert * adapter = NULL;
+   ec_adaptert * head = NULL;
    printf("SOEM (Simple Open EtherCAT Master)\nSlaveinfo\n");
 
    if (argc > 1)
@@ -633,12 +634,13 @@ int main(int argc, char *argv[])
       printf("Usage: slaveinfo ifname [options]\nifname = eth0 for example\nOptions :\n -sdo : print SDO info\n -map : print mapping\n");
    	/* Print the list */
       printf ("Available adapters\n");
-      adapter = ec_find_adapters ();
+      head = adapter = ec_find_adapters ();
       while (adapter != NULL)
       {
          printf ("Description : %s, Device to use for wpcap: %s\n", adapter->desc,adapter->name);
          adapter = adapter->next;
       }
+      ec_free_adapters(head);
    }
 
    printf("End program\n");


### PR DESCRIPTION
Don't overwrite the original pointer returned by ec_find_adapters(), otherwise the linked list is leaked. Instead, save original pointer to the head of the list use and `adapters` as a temporary variable. Pass the original pointer to ec_free_adapters().

For win32, ec_free_adapters() was missing entirely.