### PR TITLE
Fix `add_timespec` in `ebox.c``

### DIFF
--- a/test/linux/ebox/ebox.c
+++ b/test/linux/ebox/ebox.c
@@ -250,7 +250,7 @@ void add_timespec(struct timespec *ts, int64 addtime)
    sec = (addtime - nsec) / NSEC_PER_SEC;
    ts->tv_sec += sec;
    ts->tv_nsec += nsec;
-   if ( ts->tv_nsec > NSEC_PER_SEC )
+   if ( ts->tv_nsec >= NSEC_PER_SEC )
    {
       nsec = ts->tv_nsec % NSEC_PER_SEC;
       ts->tv_sec += (ts->tv_nsec - nsec) / NSEC_PER_SEC;

--- a/test/win32/ebox/ebox.c
+++ b/test/win32/ebox/ebox.c
@@ -250,7 +250,7 @@ void add_timespec(struct timespec *ts, int64 addtime)
    sec = (addtime - nsec) / NSEC_PER_SEC;
    ts->tv_sec += sec;
    ts->tv_nsec += nsec;
-   if ( ts->tv_nsec > NSEC_PER_SEC )
+   if ( ts->tv_nsec >= NSEC_PER_SEC )
    {
       nsec = ts->tv_nsec % NSEC_PER_SEC;
       ts->tv_sec += (ts->tv_nsec - nsec) / NSEC_PER_SEC;


### PR DESCRIPTION
Hello rt-labs AB,

I've found an error about the function `add_timespec` in test files `red_test.c` and `ebox.c` when I'm working with the release version `v1.4.0`. It was partially fixed in this pull request [https://github.com/OpenEtherCATsociety/SOEM/pull/460#issue-739384597](https://github.com/OpenEtherCATsociety/SOEM/pull/460#issue-739384597).
But it only fixed  `add_timespec` in `red_test.c`. I fixed this in `ebox.c` as well.

And I've sent the license agreement by email already.