### PR TITLE
Fix poor accuracy due to repeat open and close of NIC.

### DIFF
--- a/osal/win32/osal.c
+++ b/osal/win32/osal.c
@@ -17,7 +17,6 @@ int osal_getrelativetime(struct timeval *tv, struct timezone *tz)
    int64_t wintime, usecs;
    if(!sysfrequency)
    {
-      timeBeginPeriod(1);
       QueryPerformanceFrequency((LARGE_INTEGER *)&sysfrequency);
       qpc2usec = 1000000.0 / sysfrequency;
    }

--- a/oshw/win32/nicdrv.c
+++ b/oshw/win32/nicdrv.c
@@ -89,6 +89,8 @@ static void ecx_clear_rxbufstat(int *rxbufstat)
  */
 int ecx_setupnic(ecx_portt *port, const char *ifname, int secondary)
 {
+   timeBeginPeriod(1);
+   
    int i, rval;
    pcap_t **psock;
 


### PR DESCRIPTION
use case

ec_init
ec_config_init //timeBeginPeriod(1) call once
//do something
close_nic //timeEndPeriod(1)
//continue
ec_init
ec_config_init // timeBeginPeriod(1) will not called
//poor accuracy 
close_nic //timeEndPeriod(1)

This fix resolves this issue.
