### PR TITLE
Rename PACKED macro to SOEM_PACKED to avoid collision with fmtlib

### DIFF
--- a/doc/tutorial.txt
+++ b/doc/tutorial.txt
@@ -326,7 +326,7 @@ set_output_int16(EL4001_1,0,slave_EL4001_1.out1);
 Target can handle non aligned pointers to the IOmap
 \code
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
 	int16	   outvalue1;
 	int16	   outvalue2;

--- a/osal/erika/osal_defs.h
+++ b/osal/erika/osal_defs.h
@@ -24,11 +24,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 int osal_gettimeofday(struct timeval *tv, struct timezone *tz);
 void *osal_malloc(size_t size);

--- a/osal/intime/osal_defs.h
+++ b/osal/intime/osal_defs.h
@@ -20,16 +20,14 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-    #ifdef _MSC_VER
-    #define PACKED_BEGIN __pragma(pack(push, 1))
-    #define PACKED
-    #define PACKED_END __pragma(pack(pop))
-    #elif defined(__GNUC__)
-    #define PACKED_BEGIN
-    #define PACKED  __attribute__((__packed__))
-    #define PACKED_END
-    #endif
+#ifdef _MSC_VER
+#define SOEM_PACKED_BEGIN __pragma(pack(push, 1))
+#define SOEM_PACKED
+#define SOEM_PACKED_END __pragma(pack(pop))
+#elif defined(__GNUC__)
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 #endif
 
 #define OSAL_THREAD_HANDLE   RTHANDLE

--- a/osal/linux/osal_defs.h
+++ b/osal/linux/osal_defs.h
@@ -20,11 +20,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 #include <pthread.h>
 #define OSAL_THREAD_HANDLE pthread_t *

--- a/osal/macosx/osal_defs.h
+++ b/osal/macosx/osal_defs.h
@@ -20,11 +20,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 #include <pthread.h>
 #define OSAL_THREAD_HANDLE pthread_t *

--- a/osal/rtems/osal_defs.h
+++ b/osal/rtems/osal_defs.h
@@ -20,11 +20,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 #include <pthread.h>
 #define OSAL_THREAD_HANDLE pthread_t *

--- a/osal/rtk/osal_defs.h
+++ b/osal/rtk/osal_defs.h
@@ -20,11 +20,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 #define OSAL_THREAD_HANDLE task_t *
 #define OSAL_THREAD_FUNC void

--- a/osal/vxworks/osal_defs.h
+++ b/osal/vxworks/osal_defs.h
@@ -15,11 +15,9 @@
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN
-#define PACKED  __attribute__((__packed__))
-#define PACKED_END
-#endif
+#define SOEM_PACKED_BEGIN
+#define SOEM_PACKED __attribute__((__packed__))
+#define SOEM_PACKED_END
 
 #define OSAL_THREAD_HANDLE TASK_ID
 #define OSAL_THREAD_FUNC void

--- a/osal/win32/osal_defs.h
+++ b/osal/win32/osal_defs.h
@@ -20,11 +20,9 @@ extern "C"
 #define EC_PRINT(...) do {} while (0)
 #endif
 
-#ifndef PACKED
-#define PACKED_BEGIN __pragma(pack(push, 1))
-#define PACKED
-#define PACKED_END __pragma(pack(pop))
-#endif
+#define SOEM_PACKED_BEGIN __pragma(pack(push, 1))
+#define SOEM_PACKED
+#define SOEM_PACKED_END __pragma(pack(pop))
 
 #define OSAL_THREAD_HANDLE HANDLE
 #define OSAL_THREAD_FUNC void

--- a/soem/ethercatcoe.c
+++ b/soem/ethercatcoe.c
@@ -20,8 +20,8 @@
 #include "ethercatcoe.h"
 
 /** SDO structure, not to be confused with EcSDOserviceT */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert   MbxHeader;
    uint16          CANOpen;
@@ -35,11 +35,11 @@ typedef struct PACKED
       uint32  ldata[0x80];
    };
 } ec_SDOt;
-PACKED_END
+SOEM_PACKED_END
 
 /** SDO service structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert   MbxHeader;
    uint16          CANOpen;
@@ -53,7 +53,7 @@ typedef struct PACKED
       uint32  ldata[0x80];
    };
 } ec_SDOservicet;
-PACKED_END
+SOEM_PACKED_END
 
 /** Report SDO error.
  *

--- a/soem/ethercateoe.h
+++ b/soem/ethercateoe.h
@@ -133,12 +133,12 @@ typedef struct eoe_ip4_addr {
 }eoe_ip4_addr_t;
 
 /** EOE ethernet address */
-PACKED_BEGIN
-typedef struct PACKED eoe_ethaddr
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED eoe_ethaddr
 {
    uint8_t addr[EOE_ETHADDR_LENGTH];
 } eoe_ethaddr_t;
-PACKED_END
+SOEM_PACKED_END
 
 /** EoE IP request structure, storage only, no need to pack */
 typedef struct eoe_param
@@ -160,8 +160,8 @@ typedef struct eoe_param
 /** EOE structure.
 * Used to interpret EoE mailbox packets.
 */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert mbxheader;
    uint16_t frameinfo1;
@@ -172,7 +172,7 @@ typedef struct PACKED
    };
    uint8 data[EC_MAXEOEDATA];
 } ec_EOEt;
-PACKED_END
+SOEM_PACKED_END
 
 int ecx_EOEdefinehook(ecx_contextt *context, void *hook);
 int ecx_EOEsetIp(ecx_contextt *context, 

--- a/soem/ethercatfoe.c
+++ b/soem/ethercatfoe.c
@@ -24,8 +24,8 @@
 /** FOE structure.
  * Used for Read, Write, Data, Ack and Error mailbox packets.
  */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert MbxHeader;
    uint8         OpCode;
@@ -43,7 +43,7 @@ typedef struct PACKED
       char          ErrorText[EC_MAXFOEDATA];
    };
 } ec_FOEt;
-PACKED_END
+SOEM_PACKED_END
 
 /** FoE progress hook.
  *

--- a/soem/ethercatmain.c
+++ b/soem/ethercatmain.c
@@ -26,28 +26,28 @@
 #define EC_LOCALDELAY  200
 
 /** record for ethercat eeprom communications */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    uint16    comm;
    uint16    addr;
    uint16    d2;
 } ec_eepromt;
-PACKED_END
+SOEM_PACKED_END
 
 /** mailbox error structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert   MbxHeader;
    uint16          Type;
    uint16          Detail;
 } ec_mbxerrort;
-PACKED_END
+SOEM_PACKED_END
 
 /** emergency request structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert   MbxHeader;
    uint16          CANOpen;
@@ -56,7 +56,7 @@ typedef struct PACKED
    uint8           bData;
    uint16          w1,w2;
 } ec_emcyt;
-PACKED_END
+SOEM_PACKED_END
 
 #ifdef EC_VER1
 /** Main slave data array.

--- a/soem/ethercatmain.h
+++ b/soem/ethercatmain.h
@@ -49,8 +49,8 @@ struct ec_adapter
 };
 
 /** record for FMMU */
-PACKED_BEGIN
-typedef struct PACKED ec_fmmu
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_fmmu
 {
    uint32  LogStart;
    uint16  LogLength;
@@ -63,26 +63,26 @@ typedef struct PACKED ec_fmmu
    uint8   unused1;
    uint16  unused2;
 }  ec_fmmut;
-PACKED_END
+SOEM_PACKED_END
 
 /** record for sync manager */
-PACKED_BEGIN
-typedef struct PACKED ec_sm
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_sm
 {
    uint16  StartAddr;
    uint16  SMlength;
    uint32  SMflags;
 } ec_smt;
-PACKED_END
+SOEM_PACKED_END
 
-PACKED_BEGIN
-typedef struct PACKED ec_state_status
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_state_status
 {
    uint16  State;
    uint16  Unused;
    uint16  ALstatuscode;
 } ec_state_status;
-PACKED_END
+SOEM_PACKED_END
 
 #define ECT_MBXPROT_AOE      0x0001
 #define ECT_MBXPROT_EOE      0x0002
@@ -312,25 +312,25 @@ typedef struct ec_eepromPDO
 typedef uint8 ec_mbxbuft[EC_MAXMBX + 1];
 
 /** standard ethercat mailbox header */
-PACKED_BEGIN
-typedef struct PACKED ec_mbxheader
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_mbxheader
 {
    uint16  length;
    uint16  address;
    uint8   priority;
    uint8   mbxtype;
 } ec_mbxheadert;
-PACKED_END
+SOEM_PACKED_END
 
 /** ALstatus and ALstatus code */
-PACKED_BEGIN
-typedef struct PACKED ec_alstatus
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_alstatus
 {
    uint16  alstatus;
    uint16  unused;
    uint16  alstatuscode;
 } ec_alstatust;
-PACKED_END
+SOEM_PACKED_END
 
 /** stack structure to store segmented LRD/LWR/LRW constructs */
 typedef struct ec_idxstack
@@ -352,34 +352,34 @@ typedef struct ec_ering
 } ec_eringt;
 
 /** SyncManager Communication Type structure for CA */
-PACKED_BEGIN
-typedef struct PACKED ec_SMcommtype
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_SMcommtype
 {
    uint8   n;
    uint8   nu1;
    uint8   SMtype[EC_MAXSM];
 } ec_SMcommtypet;
-PACKED_END
+SOEM_PACKED_END
 
 /** SDO assign structure for CA */
-PACKED_BEGIN
-typedef struct PACKED ec_PDOassign
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_PDOassign
 {
    uint8   n;
    uint8   nu1;
    uint16  index[256];
 } ec_PDOassignt;
-PACKED_END
+SOEM_PACKED_END
 
 /** SDO description structure for CA */
-PACKED_BEGIN
-typedef struct PACKED ec_PDOdesc
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED ec_PDOdesc
 {
    uint8   n;
    uint8   nu1;
    uint32  PDO[256];
 } ec_PDOdesct;
-PACKED_END
+SOEM_PACKED_END
 
 /** Context structure , referenced by all ecx functions*/
 struct ecx_context

--- a/soem/ethercatsoe.c
+++ b/soem/ethercatsoe.c
@@ -20,8 +20,8 @@
 #define EC_SOE_MAX_DRIVES 8
 
 /** SoE (Servo over EtherCAT) mailbox structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    ec_mbxheadert MbxHeader;
    uint8         opCode         :3;
@@ -35,7 +35,7 @@ typedef struct PACKED
       uint16     fragmentsleft;
    };
 } ec_SoEt;
-PACKED_END
+SOEM_PACKED_END
 
 /** Report SoE error.
  *

--- a/soem/ethercatsoe.h
+++ b/soem/ethercatsoe.h
@@ -32,8 +32,8 @@ extern "C"
 #define EC_IDN_ATCONFIG      16
 
 /** SoE name structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** current length in bytes of list */
    uint16     currentlength;
@@ -41,11 +41,11 @@ typedef struct PACKED
    uint16     maxlength;
    char       name[EC_SOE_MAXNAME];
 } ec_SoEnamet;
-PACKED_END
+SOEM_PACKED_END
 
 /** SoE list structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** current length in bytes of list */
    uint16     currentlength;
@@ -59,11 +59,11 @@ typedef struct PACKED
       uint64  lword[1];
    };
 } ec_SoElistt;
-PACKED_END
+SOEM_PACKED_END
 
 /** SoE IDN mapping structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** current length in bytes of list */
    uint16     currentlength;
@@ -71,7 +71,7 @@ typedef struct PACKED
    uint16     maxlength;
    uint16     idn[EC_SOE_MAXMAPPING];
 } ec_SoEmappingt;
-PACKED_END
+SOEM_PACKED_END
 
 #define EC_SOE_LENGTH_1         0x00
 #define EC_SOE_LENGTH_2         0x01
@@ -87,8 +87,8 @@ PACKED_END
 #define EC_SOE_TYPE_PARAMETER   0x07
 
 /** SoE attribute structure */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** evaluation factor for display purposes */
    uint32     evafactor   :16;
@@ -111,7 +111,7 @@ typedef struct PACKED
    uint32     wpop        :1;
    uint32     reserved2   :1;
 } ec_SoEattributet;
-PACKED_END
+SOEM_PACKED_END
 
 #ifdef EC_VER1
 int ec_SoEread(uint16 slave, uint8 driveNo, uint8 elementflags, uint16 idn, int *psize, void *p, int timeout);

--- a/soem/ethercattype.h
+++ b/soem/ethercattype.h
@@ -87,8 +87,8 @@ extern "C"
 typedef uint8 ec_bufT[EC_BUFSIZE];
 
 /** ethernet header definition */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** destination MAC */
    uint16  da0,da1,da2;
@@ -97,14 +97,14 @@ typedef struct PACKED
    /** ethernet type */
    uint16  etype;
 } ec_etherheadert;
-PACKED_END
+SOEM_PACKED_END
 
 /** ethernet header size */
 #define ETH_HEADERSIZE      sizeof(ec_etherheadert)
 
 /** EtherCAT datagram header definition */
-PACKED_BEGIN
-typedef struct PACKED
+SOEM_PACKED_BEGIN
+typedef struct SOEM_PACKED
 {
    /** length of EtherCAT datagram */
    uint16  elength;
@@ -121,7 +121,7 @@ typedef struct PACKED
    /** interrupt, currently unused */
    uint16  irpt;
 } ec_comt;
-PACKED_END
+SOEM_PACKED_END
 
 /** EtherCAT header size */
 #define EC_HEADERSIZE       sizeof(ec_comt)

--- a/test/linux/ebox/ebox.c
+++ b/test/linux/ebox/ebox.c
@@ -25,7 +25,7 @@
 
 #define NSEC_PER_SEC 1000000000
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         status;
    uint8         counter;
@@ -35,13 +35,13 @@ typedef struct PACKED
    int32         enc[2];
 } in_EBOXt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         counter;
    int16         stream[100];
 } in_EBOX_streamt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         control;
    uint8         dout;
@@ -49,7 +49,7 @@ typedef struct PACKED
    uint16        pwmout[2];
 } out_EBOXt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         control;
 } out_EBOX_streamt;

--- a/test/win32/ebox/ebox.c
+++ b/test/win32/ebox/ebox.c
@@ -25,7 +25,7 @@
 
 #define NSEC_PER_SEC 1000000000
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         status;
    uint8         counter;
@@ -35,13 +35,13 @@ typedef struct PACKED
    int32         enc[2];
 } in_EBOXt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         counter;
    int16         stream[100];
 } in_EBOX_streamt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         control;
    uint8         dout;
@@ -49,7 +49,7 @@ typedef struct PACKED
    uint16        pwmout[2];
 } out_EBOXt;
 
-typedef struct PACKED
+typedef struct SOEM_PACKED
 {
    uint8         control;
 } out_EBOX_streamt;


### PR DESCRIPTION
There is an unfortunate collision between SOEM and [fmtlib](https://github.com/fmtlib/fmt), where SOEM's definition of a `PACKED` macro collides with a [template parameter in fmtlib](https://github.com/fmtlib/fmt/blob/92cdbbae06fe43f87a6c59eb1d623bb5abc8405d/include/fmt/base.h#L1649).

This causes some rather inscrutable compile errors, and isn't handled by the existing `#ifndef` check as fmtlib's usage is not a macro.