### PR TITLE
fix single device inputs/outputs overruning segment size

### DIFF
--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -1208,6 +1208,13 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
 
                diff = LogAddr - oLogAddr;
                oLogAddr = LogAddr;
+               if ((segmentsize + diff) > segmentmaxsize && diff <= segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
+               {
+                  context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
+                  segmentsize = 0;
+                  context->grouplist[group].outputsWKC++;
+                  segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
+               }
                segmentsize += diff;
                while (segmentsize > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
                {
@@ -1227,14 +1234,14 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
          LogAddr++;
          oLogAddr = LogAddr;
          BitPos = 0;
-         segmentsize += 1;
-         while (segmentsize > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
+         if ((segmentsize + 1) > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
          {
-            context->grouplist[group].IOsegment[currentsegment++] = segmentmaxsize;
-            segmentsize -= segmentmaxsize;
+            context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
+            segmentsize = 0;
             context->grouplist[group].outputsWKC++;
             segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
          }
+         segmentsize += 1;
       }
       context->grouplist[group].outputs = pIOmap;
       context->grouplist[group].Obytes = LogAddr - context->grouplist[group].logstartaddr;
@@ -1272,6 +1279,13 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
 
                diff = LogAddr - oLogAddr;
                oLogAddr = LogAddr;
+               if ((segmentsize + diff) > segmentmaxsize && diff <= segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
+               {
+                  context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
+                  segmentsize = 0;
+                  context->grouplist[group].inputsWKC++;
+                  segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
+               }
                segmentsize += diff;
                while (segmentsize > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
                {
@@ -1308,13 +1322,13 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
          LogAddr++;
          oLogAddr = LogAddr;
          BitPos = 0;
-         segmentsize += 1;
-         while (segmentsize > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
+         if ((segmentsize + 1) > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
          {
-            context->grouplist[group].IOsegment[currentsegment++] = segmentmaxsize;
-            segmentsize -= segmentmaxsize;
+            context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
+            segmentsize = 0;
             context->grouplist[group].inputsWKC++;
          }
+         segmentsize += 1;
       }
       context->grouplist[group].IOsegment[currentsegment] = segmentsize;
       context->grouplist[group].nsegments = currentsegment + 1;
@@ -1439,6 +1453,14 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
             int soLength = soLogAddr - mLogAddr;
             int siLength = siLogAddr - mLogAddr;
             mLogAddr = tempLogAddr;
+            if ((segmentsize + diff) > segmentmaxsize && diff <= segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
+            {
+               context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
+               segmentsize = 0;
+               context->grouplist[group].inputsWKC += (siLength > 0);
+               context->grouplist[group].outputsWKC += (soLength > 0);
+               segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
+            }
             segmentsize += diff;
             while (segmentsize > segmentmaxsize && currentsegment < EC_MAXIOSEGMENTS)
             {

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -1032,9 +1032,9 @@ static void ecx_config_create_input_mappings(ecx_contextt *context, void *pIOmap
    }
    context->slavelist[slave].FMMUunused = FMMUc;
 
-   /* Add one WKC for an input if flag is true */
+   /* Add one WKC for each input segment if flag is true */
    if (AddToInputsWKC)
-      context->grouplist[group].inputsWKC++;
+      context->grouplist[group].inputsWKC += 1 + (FMMUsize / (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM));
 }
 
 static void ecx_config_create_output_mappings(ecx_contextt *context, void *pIOmap,
@@ -1170,9 +1170,9 @@ static void ecx_config_create_output_mappings(ecx_contextt *context, void *pIOma
       FMMUc++;
    }
    context->slavelist[slave].FMMUunused = FMMUc;
-   /* Add one WKC for an output if flag is true */
+   /* Add one WKC for each output segment if flag is true */
    if (AddToOutputsWKC)
-      context->grouplist[group].outputsWKC++;
+      context->grouplist[group].outputsWKC += 1 + (FMMUsize / (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM));
 }
 
 static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 group, boolean forceByteAlignment)
@@ -1218,7 +1218,7 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                      LogAddr++;
                      BitPos = 0;
                   }
-               } 
+               }
 
                diff = LogAddr - oLogAddr;
                oLogAddr = LogAddr;
@@ -1285,7 +1285,7 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
             {
 
                ecx_config_create_input_mappings(context, pIOmap, group, slave, &LogAddr, &BitPos);
-               
+
                if (forceByteAlignment)
                {
                   /* Force byte alignment if the input is < 8 bits */
@@ -1294,7 +1294,7 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                      LogAddr++;
                      BitPos = 0;
                   }
-               } 
+               }
 
                diff = LogAddr - oLogAddr;
                oLogAddr = LogAddr;

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -1212,7 +1212,6 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                {
                   context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
                   segmentsize = 0;
-                  context->grouplist[group].outputsWKC++;
                   segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
                }
                segmentsize += diff;
@@ -1283,7 +1282,6 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                {
                   context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
                   segmentsize = 0;
-                  context->grouplist[group].inputsWKC++;
                   segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
                }
                segmentsize += diff;
@@ -1457,8 +1455,6 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
             {
                context->grouplist[group].IOsegment[currentsegment++] = segmentsize;
                segmentsize = 0;
-               context->grouplist[group].inputsWKC += (siLength > 0);
-               context->grouplist[group].outputsWKC += (soLength > 0);
                segmentmaxsize = EC_MAXLRWDATA; /* can ignore DC overhead after first segment */
             }
             segmentsize += diff;

--- a/soem/ethercatconfig.c
+++ b/soem/ethercatconfig.c
@@ -893,7 +893,7 @@ static void ecx_config_find_mappings(ecx_contextt *context, uint8 group)
    }
 }
 
-static void ecx_config_create_input_mappings(ecx_contextt *context, void *pIOmap, 
+static void ecx_config_create_input_mappings(ecx_contextt *context, void *pIOmap,
    uint8 group, int16 slave, uint32 * LogAddr, uint8 * BitPos)
 {
    int BitCount = 0;
@@ -1012,8 +1012,8 @@ static void ecx_config_create_input_mappings(ecx_contextt *context, void *pIOmap
          if (group)
          {
             context->slavelist[slave].inputs =
-               (uint8 *)(pIOmap) + 
-               etohl(context->slavelist[slave].FMMU[FMMUc].LogStart) - 
+               (uint8 *)(pIOmap) +
+               etohl(context->slavelist[slave].FMMU[FMMUc].LogStart) -
                context->grouplist[group].logstartaddr;
          }
          else
@@ -1037,7 +1037,7 @@ static void ecx_config_create_input_mappings(ecx_contextt *context, void *pIOmap
       context->grouplist[group].inputsWKC++;
 }
 
-static void ecx_config_create_output_mappings(ecx_contextt *context, void *pIOmap, 
+static void ecx_config_create_output_mappings(ecx_contextt *context, void *pIOmap,
    uint8 group, int16 slave, uint32 * LogAddr, uint8 * BitPos)
 {
    int BitCount = 0;
@@ -1150,14 +1150,14 @@ static void ecx_config_create_output_mappings(ecx_contextt *context, void *pIOma
          if (group)
          {
             context->slavelist[slave].outputs =
-               (uint8 *)(pIOmap) + 
-               etohl(context->slavelist[slave].FMMU[FMMUc].LogStart) - 
+               (uint8 *)(pIOmap) +
+               etohl(context->slavelist[slave].FMMU[FMMUc].LogStart) -
                context->grouplist[group].logstartaddr;
          }
          else
          {
             context->slavelist[slave].outputs =
-               (uint8 *)(pIOmap) + 
+               (uint8 *)(pIOmap) +
                etohl(context->slavelist[slave].FMMU[FMMUc].LogStart);
          }
          context->slavelist[slave].Ostartbit =
@@ -1228,8 +1228,13 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                   if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                   {
                      currentsegment++;
-                     segmentsize = diff;
                   }
+                  while (diff > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM) && currentsegment < (EC_MAXIOSEGMENTS - 1))
+                  {
+                    context->grouplist[group].IOsegment[currentsegment++] = (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+                    diff -= (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+                  }
+                  segmentsize = diff;
                }
                else
                {
@@ -1265,7 +1270,7 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
       if (!group)
       {
          context->slavelist[0].outputs = pIOmap;
-         context->slavelist[0].Obytes = LogAddr - 
+         context->slavelist[0].Obytes = LogAddr -
             context->grouplist[group].logstartaddr; /* store output bytes in master record */
       }
 
@@ -1278,7 +1283,7 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
             /* create input mapping */
             if (context->slavelist[slave].Ibits)
             {
- 
+
                ecx_config_create_input_mappings(context, pIOmap, group, slave, &LogAddr, &BitPos);
                
                if (forceByteAlignment)
@@ -1299,8 +1304,13 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
                   if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                   {
                      currentsegment++;
-                     segmentsize = diff;
                   }
+                  while (diff > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM) && currentsegment < (EC_MAXIOSEGMENTS - 1))
+                  {
+                    context->grouplist[group].IOsegment[currentsegment++] = (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+                    diff -= (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+                  }
+                  segmentsize = diff;
                }
                else
                {
@@ -1348,14 +1358,14 @@ static int ecx_main_config_map_group(ecx_contextt *context, void *pIOmap, uint8 
       context->grouplist[group].IOsegment[currentsegment] = segmentsize;
       context->grouplist[group].nsegments = currentsegment + 1;
       context->grouplist[group].inputs = (uint8 *)(pIOmap) + context->grouplist[group].Obytes;
-      context->grouplist[group].Ibytes = LogAddr - 
-         context->grouplist[group].logstartaddr - 
+      context->grouplist[group].Ibytes = LogAddr -
+         context->grouplist[group].logstartaddr -
          context->grouplist[group].Obytes;
       if (!group)
       {
          context->slavelist[0].inputs = (uint8 *)(pIOmap) + context->slavelist[0].Obytes;
-         context->slavelist[0].Ibytes = LogAddr - 
-            context->grouplist[group].logstartaddr - 
+         context->slavelist[0].Ibytes = LogAddr -
+            context->grouplist[group].logstartaddr -
             context->slavelist[0].Obytes; /* store input bytes in master record */
       }
 
@@ -1428,7 +1438,7 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
 
       /* Find mappings and program syncmanagers */
       ecx_config_find_mappings(context, group);
-      
+
       /* do IO mapping of slave and program FMMUs */
       for (slave = 1; slave <= *(context->slavecount); slave++)
       {
@@ -1440,8 +1450,8 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
             /* create output mapping */
             if (context->slavelist[slave].Obits)
             {
-               
-               ecx_config_create_output_mappings(context, pIOmap, group, 
+
+               ecx_config_create_output_mappings(context, pIOmap, group,
                   slave, &soLogAddr, &BitPos);
                if (BitPos)
                {
@@ -1453,7 +1463,7 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
             /* create input mapping */
             if (context->slavelist[slave].Ibits)
             {
-               ecx_config_create_input_mappings(context, pIOmap, group, 
+               ecx_config_create_input_mappings(context, pIOmap, group,
                   slave, &siLogAddr, &BitPos);
                if (BitPos)
                {
@@ -1472,8 +1482,13 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
                if (currentsegment < (EC_MAXIOSEGMENTS - 1))
                {
                   currentsegment++;
-                  segmentsize = diff;
                }
+               while (diff > (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM) && currentsegment < (EC_MAXIOSEGMENTS - 1))
+               {
+                 context->grouplist[group].IOsegment[currentsegment++] = (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+                 diff -= (EC_MAXLRWDATA - EC_FIRSTDCDATAGRAM);
+               }
+               segmentsize = diff;
             }
             else
             {
@@ -1526,7 +1541,7 @@ int ecx_config_overlap_map_group(ecx_contextt *context, void *pIOmap, uint8 grou
       {
          /* store output bytes in master record */
          context->slavelist[0].outputs = pIOmap;
-         context->slavelist[0].Obytes = soLogAddr - context->grouplist[group].logstartaddr; 
+         context->slavelist[0].Obytes = soLogAddr - context->grouplist[group].logstartaddr;
          context->slavelist[0].inputs = (uint8 *)pIOmap + context->slavelist[0].Obytes;
          context->slavelist[0].Ibytes = siLogAddr - context->grouplist[group].logstartaddr;
       }
@@ -1647,7 +1662,7 @@ int ecx_reconfig_slave(ecx_contextt *context, uint16 slave, int timeout)
          if (context->slavelist[slave].PO2SOconfigx) /* only if registered */
          {
             context->slavelist[slave].PO2SOconfigx(context, slave);
-         }         
+         }
          ecx_FPWRw(context->port, configadr, ECT_REG_ALCTL, htoes(EC_STATE_SAFE_OP) , timeout); /* set safeop status */
          state = ecx_statecheck(context, slave, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE); /* check state change safe-op */
          /* program configured FMMU */


### PR DESCRIPTION
certain modular devices can have process data that exceeds a segment size. Add code to allow multiple segments within a single device. 