### PR TITLE
Update Ubuntu version used in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-20.04
-          - ubuntu-18.04
+          - ubuntu-22.04
           - macos-latest
           - windows-latest
     steps:


### PR DESCRIPTION
Ubuntu 18.04 and 20.04 are no longer supported by GitHub runners, so we should test on 22.04 and 24.04 (which we get via `ubuntu-latest`).