### PR TITLE
Replace magic number with define

### DIFF
--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -1304,7 +1304,7 @@ int ecx_mbxinhandler(ecx_contextt *context, uint8 group, int limit)
                   else if ((mbxh->mbxtype & 0x0f) == ECT_MBXT_COE) /* CoE response? */
                   {
                      EMp = (ec_emcyt *)mbx;
-                     if ((etohs(EMp->CANOpen) >> 12) == 0x01) /* Emergency request? */
+                     if ((etohs(EMp->CANOpen) >> 12) == ECT_COES_EMERGENCY) /* Emergency request? */
                      {
                         ecx_mbxemergencyerror(context, slave, etohs(EMp->ErrorCode), EMp->ErrorReg,
                                               EMp->bData, etohs(EMp->w1), etohs(EMp->w2));
@@ -1679,7 +1679,7 @@ int ecx_mbxreceive(ecx_contextt *context, uint16 slave, ec_mbxbuft **mbx, int ti
             else if ((wkc > 0) && ((mbxh->mbxtype & 0x0f) == ECT_MBXT_COE)) /* CoE response? */
             {
                EMp = (ec_emcyt *)mbx;
-               if ((etohs(EMp->CANOpen) >> 12) == 0x01) /* Emergency request? */
+               if ((etohs(EMp->CANOpen) >> 12) == ECT_COES_EMERGENCY) /* Emergency request? */
                {
                   ecx_mbxemergencyerror(context, slave, etohs(EMp->ErrorCode), EMp->ErrorReg,
                                         EMp->bData, etohs(EMp->w1), etohs(EMp->w2));


### PR DESCRIPTION
When checking for emergency requests, the CoE service is checked against a magic number. There is already a define for this, so use that instead.