### PR TITLE
Do not look up stored mappings on complex devices

### DIFF
--- a/src/ec_config.c
+++ b/src/ec_config.c
@@ -473,7 +473,15 @@ int ecx_config_init(ecx_contextt *context)
 static int ecx_lookup_mapping(ecx_contextt *context, uint16 slave, uint32 *Osize, uint32 *Isize)
 {
    int i, nSM;
-   if ((slave > 1) && (context->slavecount > 0))
+
+   /* Do not look up stored mappings on complex devices */
+   if ((context->slavelist[slave].mbx_proto & ECT_MBXPROT_COE) ||
+       (context->slavelist[slave].mbx_proto & ECT_MBXPROT_SOE))
+   {
+      return 0;
+   }
+
+   if ((slave > 1) && (context->slavecount > 0) )
    {
       i = 1;
       while (((context->slavelist[i].eep_man != context->slavelist[slave].eep_man) ||


### PR DESCRIPTION
Fixes #962 

The SII mapping logic in `ecx_map_sii` assumes that if no process data was found for CoE devices, earlier matching devices can be used. However, complex devices can have the same ID and lack process data in some instances. This fix works around the issue by only applying previous mapping data if the device is not CoE or SoE enabled.

https://github.com/OpenEtherCATsociety/SOEM/blob/b410bf6ef599d5c85302ea45cae5f55f8e9aa394/src/ec_config.c#L555-L567

https://github.com/OpenEtherCATsociety/SOEM/blob/b410bf6ef599d5c85302ea45cae5f55f8e9aa394/src/ec_config.c#L470-L473