### PR TITLE
fix: Fix NULL dereference in ecx_mbxreceive when mailbox pool is empty

### DIFF
--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -1671,7 +1671,12 @@ int ecx_mbxreceive(ecx_contextt *context, uint16 slave, ec_mbxbuft **mbx, int ti
       if ((wkc > 0) && ((SMstat & 0x08) > 0)) /* read mailbox available ? */
       {
          mbxro = slavelist->mbx_ro;
-         mbxin = ecx_getmbx(context);
+         mbxin = ecx_getmbx(context);  
+         if (mbxin == NULL) /* imbxin=NULL will cause process to crash. fix Issue #948*/
+         { 
+             *mbx = NULL;   
+             return 0;     
+         }
          mbxh = (ec_mbxheadert *)mbxin;
          do
          {

--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -1672,7 +1672,7 @@ int ecx_mbxreceive(ecx_contextt *context, uint16 slave, ec_mbxbuft **mbx, int ti
       {
          mbxro = slavelist->mbx_ro;
          mbxin = ecx_getmbx(context);  
-         if (mbxin == NULL) /* imbxin=NULL will cause process to crash. fix Issue #948*/
+         if (mbxin == NULL)
          { 
              *mbx = NULL;   
              return 0;     


### PR DESCRIPTION
## Summary
- Check the return value of `ecx_getmbx()` before dereferencing `mbxin`
- Set `*mbx` to NULL and return 0 when no mailbox buffer is available

## Problem
When the mailbox pool is exhausted, `ecx_mbxreceive()` dereferenced a NULL
pointer and caused a segfault in `slaveinfo` (reported in #948).

## Solution
Return 0 on failure, consistent with existing mailbox API semantics
(`wkc > 0` indicates success).