### PR TITLE
fix: Fix #977: Win32 Platform OSAL thread_create and thread_priority bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ install
 /doc/html
 tags
 .vscode
+.vs

--- a/osal/win32/osal.c
+++ b/osal/win32/osal.c
@@ -132,8 +132,10 @@ void osal_free(void *ptr)
 
 int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
 {
-   *(OSAL_THREAD_HANDLE *)thandle = CreateThread(NULL, stacksize, func, param, 0, NULL);
-   if (!thandle)
+   HANDLE thread;
+   thread = CreateThread(NULL, (SIZE_T)stacksize, (LPTHREAD_START_ROUTINE)func, param, 0, NULL);
+   *(OSAL_THREAD_HANDLE*)thandle = thread;
+   if (thread == NULL)
    {
       return 0;
    }
@@ -142,11 +144,13 @@ int osal_thread_create(void *thandle, int stacksize, void *func, void *param)
 
 int osal_thread_create_rt(void *thandle, int stacksize, void *func, void *param)
 {
+   HANDLE thread;
    int ret;
    ret = osal_thread_create(thandle, stacksize, func, param);
    if (ret)
    {
-      ret = SetThreadPriority(thandle, THREAD_PRIORITY_TIME_CRITICAL);
+	  thread = *(OSAL_THREAD_HANDLE*)thandle;
+      ret = SetThreadPriority(thread, THREAD_PRIORITY_TIME_CRITICAL);
    }
    return ret;
 }


### PR DESCRIPTION
fix(win32): detect CreateThread failure and pass correct handle to SetThreadPriority

osal_thread_create() checked thandle instead of CreateThread's return value,
so thread creation failures were reported as success.

osal_thread_create_rt() passed the thandle pointer to SetThreadPriority
instead of the thread HANDLE, so real-time priority was never applied.

Fixes #977