### PR TITLE
added a flag to boadcast the DC time to the slaves instead of reading it

### DIFF
--- a/include/soem/ec_main.h
+++ b/include/soem/ec_main.h
@@ -519,7 +519,7 @@ struct ecx_context
    ec_groupt grouplist[EC_MAXGROUP];
    /** ecaterror state */
    boolean ecaterror;
-   /** last DC time from slaves */
+   /** last DC time from slaves, or DC time to write to slaves */
    int64 DCtime;
 
    /** @privatesection */
@@ -568,6 +568,8 @@ struct ecx_context
    /** Do not map each slave on a byte boundary. May result in smaller
     * frame sizes. Has no effect in overlapped mode. */
    boolean packedMode;
+   /** whether to boadcast the DC time to all slaves instead of reading it */
+   boolean DCtimebcast;
 };
 
 ec_adaptert *ec_find_adapters(void);

--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -2492,7 +2492,8 @@ int ecx_send_processdata_group(ecx_contextt *context, uint8 group)
                if (first)
                {
                   /* FPRMW in second datagram */
-                  DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]), EC_CMD_FRMW, idx, FALSE,
+                  DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]),
+                                        context->DCtimebcast ? EC_CMD_BRW : EC_CMD_FRMW, idx, FALSE,
                                         context->slavelist[context->grouplist[group].DCnext].configadr,
                                         ECT_REG_DCSYSTIME, sizeof(int64), &context->DCtime);
                   first = FALSE;
@@ -2530,7 +2531,8 @@ int ecx_send_processdata_group(ecx_contextt *context, uint8 group)
                if (first)
                {
                   /* FPRMW in second datagram */
-                  DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]), EC_CMD_FRMW, idx, FALSE,
+                  DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]),
+                                        context->DCtimebcast ? EC_CMD_BRW : EC_CMD_FRMW, idx, FALSE,
                                         context->slavelist[context->grouplist[group].DCnext].configadr,
                                         ECT_REG_DCSYSTIME, sizeof(int64), &context->DCtime);
                   first = FALSE;
@@ -2571,7 +2573,8 @@ int ecx_send_processdata_group(ecx_contextt *context, uint8 group)
             if (first)
             {
                /* FPRMW in second datagram */
-               DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]), EC_CMD_FRMW, idx, FALSE,
+               DCO = ecx_adddatagram(&context->port, &(context->port.txbuf[idx]),
+                                     context->DCtimebcast ? EC_CMD_BRW : EC_CMD_FRMW, idx, FALSE,
                                      context->slavelist[context->grouplist[group].DCnext].configadr,
                                      ECT_REG_DCSYSTIME, sizeof(int64), &context->DCtime);
                first = FALSE;


### PR DESCRIPTION
When the EtherCAT master is used as the reference clock, the DC time needs to be written to the slaves, instead of read from it. To enable this functionality, a flag was added to `ecx_context` that causes `EC_CMD_BRW` to be used instead of `EC_CMD_FRMW` for the DC time.